### PR TITLE
Check if advertised addresses/hosts are available

### DIFF
--- a/pkg/controller/actuator.go
+++ b/pkg/controller/actuator.go
@@ -66,11 +66,12 @@ const (
 )
 
 var (
-	ErrSpecAction        = errors.New("action must either be 'ALLOW' or 'DENY'")
-	ErrSpecRule          = errors.New("rule must be present")
-	ErrSpecType          = errors.New("type must either be 'direct_remote_ip', 'remote_ip' or 'source_ip'")
-	ErrSpecCIDR          = errors.New("CIDRs must not be empty")
-	ErrNoExtensionsFound = errors.New("Could not list any extensions")
+	ErrSpecAction            = errors.New("action must either be 'ALLOW' or 'DENY'")
+	ErrSpecRule              = errors.New("rule must be present")
+	ErrSpecType              = errors.New("type must either be 'direct_remote_ip', 'remote_ip' or 'source_ip'")
+	ErrSpecCIDR              = errors.New("CIDRs must not be empty")
+	ErrNoExtensionsFound     = errors.New("could not list any extensions")
+	ErrNoAdvertisedAddresses = errors.New("advertised addresses are not available, likely because cluster creation has not yet completed")
 )
 
 // NewActuator returns an actuator responsible for Extension resources.
@@ -128,6 +129,11 @@ func (a *actuator) Reconcile(ctx context.Context, ex *extensionsv1alpha1.Extensi
 	}
 
 	hosts := make([]string, 0)
+
+	if cluster.Shoot.Status.AdvertisedAddresses == nil || len(cluster.Shoot.Status.AdvertisedAddresses) < 1 {
+		return ErrNoAdvertisedAddresses
+	}
+
 	for _, address := range cluster.Shoot.Status.AdvertisedAddresses {
 		hosts = append(hosts, strings.Split(address.URL, "//")[1])
 	}

--- a/pkg/envoyfilters/envoyfilters.go
+++ b/pkg/envoyfilters/envoyfilters.go
@@ -1,8 +1,13 @@
 package envoyfilters
 
 import (
+	"errors"
 	"net"
 	"strings"
+)
+
+var (
+	ErrNoHostsGiven = errors.New("no hosts were given, at least one host is needed")
 )
 
 type EnvoyFilterService struct{}
@@ -80,6 +85,9 @@ func (e *EnvoyFilterService) BuildVPNEnvoyFilterSpecForHelmChart(
 func (e *EnvoyFilterService) CreateAPIConfigPatchFromRule(
 	rule *ACLRule, hosts, alwaysAllowedCIDRs []string,
 ) (map[string]interface{}, error) {
+	if len(hosts) == 0 {
+		return nil, ErrNoHostsGiven
+	}
 	// TODO use all hosts?
 	host := hosts[0]
 	rbacName := "acl-api"

--- a/pkg/envoyfilters/envoyfilters_test.go
+++ b/pkg/envoyfilters/envoyfilters_test.go
@@ -77,6 +77,19 @@ var _ = Describe("EnvoyFilter Unit Tests", func() {
 			})
 		})
 	})
+
+	Describe("CreateAPIConfigPatchFromRule", func() {
+		When("there are no hosts", func() {
+			It("should return the appropriate error", func() {
+				rule := createRule("ALLOW", "remote_ip", "0.0.0.0/0")
+
+				result, err := e.CreateAPIConfigPatchFromRule(rule, nil, alwaysAllowedCIDRs)
+
+				Expect(err).To(Equal(ErrNoHostsGiven))
+				Expect(result).To(BeNil())
+			})
+		})
+	})
 })
 
 func createRule(action, ruleType, cidr string) *ACLRule {


### PR DESCRIPTION
This is needed because in the case of cluster creation, there is a short time span where the `AdvertisedAddresses` field of the `Cluster` object are not yet populated.