### PR TITLE
Fix ACL for APIServerProxy

### DIFF
--- a/pkg/controller/actuator.go
+++ b/pkg/controller/actuator.go
@@ -139,7 +139,6 @@ func (a *actuator) Reconcile(ctx context.Context, log logr.Logger, ex *extension
 
 	alwaysAllowedCIDRs := []string{
 		*cluster.Shoot.Spec.Networking.Nodes,
-		*cluster.Shoot.Spec.Networking.Pods,
 		cluster.Seed.Spec.Networks.Pods,
 		*cluster.Seed.Spec.Networks.Nodes,
 	}

--- a/pkg/controller/actuator.go
+++ b/pkg/controller/actuator.go
@@ -139,6 +139,7 @@ func (a *actuator) Reconcile(ctx context.Context, log logr.Logger, ex *extension
 
 	alwaysAllowedCIDRs := []string{
 		*cluster.Shoot.Spec.Networking.Nodes,
+		*cluster.Shoot.Spec.Networking.Pods,
 		cluster.Seed.Spec.Networks.Pods,
 		*cluster.Seed.Spec.Networks.Nodes,
 	}

--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -86,6 +86,7 @@ func (e *EnvoyFilterWebhook) createAdmissionResponse(
 
 		alwaysAllowedCIDRs := []string{
 			*cluster.Shoot.Spec.Networking.Nodes,
+			*cluster.Shoot.Spec.Networking.Pods,
 			cluster.Seed.Spec.Networks.Pods,
 			*cluster.Seed.Spec.Networks.Nodes,
 		}

--- a/pkg/webhook/webhook_test.go
+++ b/pkg/webhook/webhook_test.go
@@ -183,7 +183,7 @@ var _ = Describe("webhook unit test", func() {
 				Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, ext))).To(Succeed())
 			})
 
-			It("patches this rule into the filters object, including the Node CIDRs", func() {
+			It("patches this rule into the filters object, including CIDRs for Seed|Shoot nodes and pods", func() {
 				df, dfJSON := getEnvoyFilterFromFile("defaultEnvoyFilter.json", namespace)
 
 				ar := e.createAdmissionResponse(context.Background(), df, dfJSON)
@@ -297,7 +297,7 @@ var _ = Describe("webhook unit test", func() {
 				Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, ext))).To(Succeed())
 			})
 
-			It("patches this rule into the filters object, including the Node CIDRs and the OpenStack router IP", func() {
+			It("patches this rule into the filters object, including CIDRs for Seed|Shoot nodes and pods and also the OpenStack router IP", func() {
 				df, dfJSON := getEnvoyFilterFromFile("defaultEnvoyFilter.json", namespace)
 
 				ar := e.createAdmissionResponse(context.Background(), df, dfJSON)

--- a/pkg/webhook/webhook_test.go
+++ b/pkg/webhook/webhook_test.go
@@ -218,6 +218,12 @@ var _ = Describe("webhook unit test", func() {
 											},
 											{
 												"remote_ip": map[string]interface{}{
+													"address_prefix": "100.96.0.0",
+													"prefix_len":     11,
+												},
+											},
+											{
+												"remote_ip": map[string]interface{}{
 													"address_prefix": "10.96.0.0",
 													"prefix_len":     11,
 												},
@@ -322,6 +328,12 @@ var _ = Describe("webhook unit test", func() {
 												"remote_ip": map[string]interface{}{
 													"address_prefix": "10.250.0.0",
 													"prefix_len":     16,
+												},
+											},
+											{
+												"remote_ip": map[string]interface{}{
+													"address_prefix": "100.96.0.0",
+													"prefix_len":     11,
 												},
 											},
 											{


### PR DESCRIPTION
When using 'kubernetes.default.svc' from inside a Shoot and ACL extension is used, no connection is possible. 

As APIServerProxy is adding a ProxyProtocol entry for the connection, Shoot Pod CIDR needs to be in ACL allow list.