### PR TITLE
🐛  Fix wrong shoot specific CIDRs in `acl-vpn` envoyfilter

### DIFF
--- a/pkg/controller/actuator_test.go
+++ b/pkg/controller/actuator_test.go
@@ -1,9 +1,6 @@
 package controller
 
 import (
-	"encoding/json"
-
-	openstackv1alpha1 "github.com/gardener/gardener-extension-provider-openstack/pkg/apis/openstack/v1alpha1"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/stackitcloud/gardener-extension-acl/pkg/controller/config"
 	"github.com/stackitcloud/gardener-extension-acl/pkg/envoyfilters"
@@ -172,62 +169,6 @@ var _ = Describe("actuator unit test", func() {
 				// we're not testing for a specific error, as they come from the
 				// net package here - no need for us to test these
 				Expect(ValidateExtensionSpec(extSpec)).ToNot(Succeed())
-			})
-		})
-	})
-
-	Describe("ConfigureProviderSpecificAllowedCIDRs", func() {
-		When("there is an infrastructure object for which no custom behavior is required", func() {
-			It("Should leave the alwaysAllowedCIDRs slice unaltered and should not error", func() {
-				infra := &extensionsv1alpha1.Infrastructure{
-					Spec: extensionsv1alpha1.InfrastructureSpec{
-						DefaultSpec: extensionsv1alpha1.DefaultSpec{
-							Type: "non-existent",
-						},
-					},
-				}
-
-				alwaysAllowedCIDRs := []string{"a", "b"}
-
-				Expect(ConfigureProviderSpecificAllowedCIDRs(infra, &alwaysAllowedCIDRs)).To(Succeed())
-				Expect(alwaysAllowedCIDRs).To(Equal([]string{"a", "b"}))
-			})
-		})
-		When("there is an infrastructure object of type 'openstack'", func() {
-			It("Should add the router IP to the alwaysAllowedCIDRs slice and should not error", func() {
-				infraStatusJSON, err := json.Marshal(&openstackv1alpha1.InfrastructureStatus{
-					TypeMeta: metav1.TypeMeta{
-						Kind:       "InfrastructureStatus",
-						APIVersion: "openstack.provider.extensions.gardener.cloud/v1alpha1",
-					},
-					Networks: openstackv1alpha1.NetworkStatus{
-						Router: openstackv1alpha1.RouterStatus{
-							ID: "router-id",
-							IP: "10.9.8.7",
-						},
-					},
-				})
-				Expect(err).To(BeNil())
-
-				infra := &extensionsv1alpha1.Infrastructure{
-					Spec: extensionsv1alpha1.InfrastructureSpec{
-						DefaultSpec: extensionsv1alpha1.DefaultSpec{
-							Type: OpenstackTypeName,
-						},
-					},
-					Status: extensionsv1alpha1.InfrastructureStatus{
-						DefaultStatus: extensionsv1alpha1.DefaultStatus{
-							ProviderStatus: &runtime.RawExtension{
-								Raw: infraStatusJSON,
-							},
-						},
-					},
-				}
-
-				alwaysAllowedCIDRs := []string{"a", "b"}
-
-				Expect(ConfigureProviderSpecificAllowedCIDRs(infra, &alwaysAllowedCIDRs)).To(Succeed())
-				Expect(alwaysAllowedCIDRs).To(Equal([]string{"a", "b", "10.9.8.7/32"}))
 			})
 		})
 	})

--- a/pkg/envoyfilters/envoyfilters_test.go
+++ b/pkg/envoyfilters/envoyfilters_test.go
@@ -66,7 +66,7 @@ var _ = Describe("EnvoyFilter Unit Tests", func() {
 			It("Should create a filter spec matching the expected one, including the always allowed CIDRs", func() {
 				rule := createRule("ALLOW", "remote_ip", "0.0.0.0/0")
 
-				result, err := e.CreateInternalFilterPatchFromRule(rule, alwaysAllowedCIDRs)
+				result, err := e.CreateInternalFilterPatchFromRule(rule, alwaysAllowedCIDRs, []string{})
 
 				Expect(err).ToNot(HaveOccurred())
 				checkIfMapEqualsYAML(result, "singleFiltersAllowEntry.yaml")

--- a/pkg/envoyfilters/suite_test.go
+++ b/pkg/envoyfilters/suite_test.go
@@ -12,11 +12,3 @@ func TestAPIs(t *testing.T) {
 
 	RunSpecs(t, "EnvoyFilters Test Suite")
 }
-
-var _ = BeforeSuite(func() {
-
-})
-
-var _ = AfterSuite(func() {
-
-})

--- a/pkg/helper/cluster.go
+++ b/pkg/helper/cluster.go
@@ -1,0 +1,29 @@
+package helper
+
+import (
+	"context"
+	"errors"
+
+	"github.com/gardener/gardener/extensions/pkg/controller"
+	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var (
+	ErrClusterObjectNotComplete = errors.New("cluster.Seed or cluster.Shoot is nil")
+)
+
+func GetClusterForExtension(
+	ctx context.Context,
+	c client.Reader,
+	extension *extensionsv1alpha1.Extension,
+) (*controller.Cluster, error) {
+	cluster, err := controller.GetCluster(ctx, c, extension.GetNamespace())
+	if err != nil {
+		return nil, err
+	}
+	if cluster.Seed == nil || cluster.Shoot == nil {
+		return nil, ErrClusterObjectNotComplete
+	}
+	return cluster, nil
+}

--- a/pkg/helper/infrastructure.go
+++ b/pkg/helper/infrastructure.go
@@ -1,0 +1,27 @@
+package helper
+
+import (
+	"context"
+
+	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func GetInfrastructureForExtension(
+	ctx context.Context,
+	c client.Reader,
+	extension *extensionsv1alpha1.Extension,
+	shootName string,
+) (*extensionsv1alpha1.Infrastructure, error) {
+	infra := &extensionsv1alpha1.Infrastructure{}
+	namespacedName := types.NamespacedName{
+		Namespace: extension.GetNamespace(),
+		Name:      shootName,
+	}
+
+	if err := c.Get(ctx, namespacedName, infra); err != nil {
+		return nil, err
+	}
+	return infra, nil
+}

--- a/pkg/helper/provider.go
+++ b/pkg/helper/provider.go
@@ -1,0 +1,50 @@
+package helper
+
+import (
+	"encoding/json"
+	"errors"
+
+	openstackv1alpha1 "github.com/gardener/gardener-extension-provider-openstack/pkg/apis/openstack/v1alpha1"
+	"github.com/gardener/gardener-extension-provider-openstack/pkg/openstack"
+	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+)
+
+var (
+	ErrProviderStatusRawIsNil = errors.New("providerStatus.Raw is nil, and can't be unmarshalled")
+)
+
+func GetProviderSpecificAllowedCIDRs(
+	infra *extensionsv1alpha1.Infrastructure,
+) ([]string, error) {
+	cidrs := make([]string, 0)
+
+	//nolint:gocritic // Will likely be extended with other infra types in the future
+	switch infra.Spec.Type {
+	case openstack.Type:
+		// This would be our preferred solution:
+		//
+		// infraStatus, err := openstackhelper.InfrastructureStatusFromRaw(infra.Status.ProviderStatus)
+		//
+		// but decoding isn't possible. We suspect it's because in the function
+		// infraStatus is assigned like this:
+		//
+		// infraStatus := &InfrasttuctureStatus{}
+		//
+		// instead of doing it without a pointer and then referencing it in the
+		// unmarshal step, like we now have to do manually here:
+		if infra.Status.ProviderStatus == nil || infra.Status.ProviderStatus.Raw == nil {
+			return nil, ErrProviderStatusRawIsNil
+		}
+
+		infraStatus := openstackv1alpha1.InfrastructureStatus{}
+		err := json.Unmarshal(infra.Status.ProviderStatus.Raw, &infraStatus)
+		if err != nil {
+			return nil, err
+		}
+
+		router32CIDR := infraStatus.Networks.Router.IP + "/32"
+
+		cidrs = append(cidrs, router32CIDR)
+	}
+	return cidrs, nil
+}

--- a/pkg/helper/provider.go
+++ b/pkg/helper/provider.go
@@ -10,7 +10,8 @@ import (
 )
 
 var (
-	ErrProviderStatusRawIsNil = errors.New("providerStatus.Raw is nil, and can't be unmarshalled")
+	ErrProviderStatusRawIsNil  = errors.New("providerStatus.Raw is nil, and can't be unmarshalled")
+	ErrWrongInfrastructureType = errors.New("infrastructure type is not correct")
 )
 
 func GetProviderSpecificAllowedCIDRs(
@@ -21,30 +22,46 @@ func GetProviderSpecificAllowedCIDRs(
 	//nolint:gocritic // Will likely be extended with other infra types in the future
 	switch infra.Spec.Type {
 	case openstack.Type:
-		// This would be our preferred solution:
-		//
-		// infraStatus, err := openstackhelper.InfrastructureStatusFromRaw(infra.Status.ProviderStatus)
-		//
-		// but decoding isn't possible. We suspect it's because in the function
-		// infraStatus is assigned like this:
-		//
-		// infraStatus := &InfrasttuctureStatus{}
-		//
-		// instead of doing it without a pointer and then referencing it in the
-		// unmarshal step, like we now have to do manually here:
-		if infra.Status.ProviderStatus == nil || infra.Status.ProviderStatus.Raw == nil {
-			return nil, ErrProviderStatusRawIsNil
-		}
-
-		infraStatus := openstackv1alpha1.InfrastructureStatus{}
-		err := json.Unmarshal(infra.Status.ProviderStatus.Raw, &infraStatus)
+		openstackCIDRs, err := getOpenstackProviderSpecificAllowedCIDRs(infra)
 		if err != nil {
 			return nil, err
 		}
-
-		router32CIDR := infraStatus.Networks.Router.IP + "/32"
-
-		cidrs = append(cidrs, router32CIDR)
+		cidrs = append(cidrs, openstackCIDRs...)
 	}
+	return cidrs, nil
+}
+
+func getOpenstackProviderSpecificAllowedCIDRs(
+	infra *extensionsv1alpha1.Infrastructure,
+) ([]string, error) {
+	if infra.Spec.Type != openstack.Type {
+		return nil, ErrWrongInfrastructureType
+	}
+	cidrs := make([]string, 0)
+	// This would be our preferred solution:
+	//
+	// infraStatus, err := openstackhelper.InfrastructureStatusFromRaw(infra.Status.ProviderStatus)
+	//
+	// but decoding isn't possible. We suspect it's because in the function
+	// infraStatus is assigned like this:
+	//
+	// infraStatus := &InfrasttuctureStatus{}
+	//
+	// instead of doing it without a pointer and then referencing it in the
+	// unmarshal step, like we now have to do manually here:
+	if infra.Status.ProviderStatus == nil || infra.Status.ProviderStatus.Raw == nil {
+		return nil, ErrProviderStatusRawIsNil
+	}
+
+	infraStatus := openstackv1alpha1.InfrastructureStatus{}
+	err := json.Unmarshal(infra.Status.ProviderStatus.Raw, &infraStatus)
+	if err != nil {
+		return nil, err
+	}
+
+	router32CIDR := infraStatus.Networks.Router.IP + "/32"
+
+	cidrs = append(cidrs, router32CIDR)
+
 	return cidrs, nil
 }

--- a/pkg/helper/provider_test.go
+++ b/pkg/helper/provider_test.go
@@ -1,0 +1,78 @@
+package helper
+
+import (
+	"encoding/json"
+
+	openstackv1alpha1 "github.com/gardener/gardener-extension-provider-openstack/pkg/apis/openstack/v1alpha1"
+	"github.com/gardener/gardener-extension-provider-openstack/pkg/openstack"
+	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+// TODO Add test for the acl-api-shoot and acl-vpn envoy filter
+
+var _ = Describe("provider Unit Tests", func() {
+	Describe("GetProviderSpecificAllowedCIDRs", func() {
+		When("there is an infrastructure object for which no custom behavior is required", func() {
+			It("Should leave the alwaysAllowedCIDRs slice unaltered and should not error", func() {
+				infra := &extensionsv1alpha1.Infrastructure{
+					Spec: extensionsv1alpha1.InfrastructureSpec{
+						DefaultSpec: extensionsv1alpha1.DefaultSpec{
+							Type: "non-existent",
+						},
+					},
+				}
+
+				allowedCIDRs := []string{"a", "b"}
+				providerIPs, err := GetProviderSpecificAllowedCIDRs(infra)
+				Expect(err).To(Succeed())
+
+				allowedCIDRs = append(allowedCIDRs, providerIPs...)
+				Expect(allowedCIDRs).To(Equal([]string{"a", "b"}))
+			})
+		})
+		When("there is an infrastructure object of type 'openstack'", func() {
+			It("Should add the router IP to the alwaysAllowedCIDRs slice and should not error", func() {
+				infraStatusJSON, err := json.Marshal(&openstackv1alpha1.InfrastructureStatus{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "InfrastructureStatus",
+						APIVersion: "openstack.provider.extensions.gardener.cloud/v1alpha1",
+					},
+					Networks: openstackv1alpha1.NetworkStatus{
+						Router: openstackv1alpha1.RouterStatus{
+							ID: "router-id",
+							IP: "10.9.8.7",
+						},
+					},
+				})
+				Expect(err).To(BeNil())
+
+				infra := &extensionsv1alpha1.Infrastructure{
+					Spec: extensionsv1alpha1.InfrastructureSpec{
+						DefaultSpec: extensionsv1alpha1.DefaultSpec{
+							Type: openstack.Type,
+						},
+					},
+					Status: extensionsv1alpha1.InfrastructureStatus{
+						DefaultStatus: extensionsv1alpha1.DefaultStatus{
+							ProviderStatus: &runtime.RawExtension{
+								Raw: infraStatusJSON,
+							},
+						},
+					},
+				}
+
+				allowedCIDRs := []string{"a", "b"}
+				providerIPs, err := GetProviderSpecificAllowedCIDRs(infra)
+				Expect(err).To(Succeed())
+
+				allowedCIDRs = append(allowedCIDRs, providerIPs...)
+				Expect(allowedCIDRs).To(Equal([]string{"a", "b", "10.9.8.7/32"}))
+			})
+		})
+	})
+})

--- a/pkg/helper/seed.go
+++ b/pkg/helper/seed.go
@@ -1,0 +1,16 @@
+package helper
+
+import (
+	"github.com/gardener/gardener/pkg/apis/core/v1beta1"
+)
+
+func GetSeedSpecificAllowedCIDRs(seed *v1beta1.Seed) []string {
+	cidrs := make([]string, 0)
+	if seed.Spec.Networks.Nodes != nil {
+		cidrs = append(cidrs, *seed.Spec.Networks.Nodes)
+	}
+	if seed.Spec.Networks.Pods != "" {
+		cidrs = append(cidrs, seed.Spec.Networks.Pods)
+	}
+	return cidrs
+}

--- a/pkg/helper/shoot.go
+++ b/pkg/helper/shoot.go
@@ -1,0 +1,29 @@
+package helper
+
+import (
+	"github.com/gardener/gardener/pkg/apis/core/v1beta1"
+)
+
+func GetShootNodeSpecificAllowedCIDRs(shoot *v1beta1.Shoot) []string {
+	cidrs := make([]string, 0)
+
+	if shoot.Spec.Networking == nil {
+		return cidrs
+	}
+	if shoot.Spec.Networking.Nodes != nil {
+		cidrs = append(cidrs, *shoot.Spec.Networking.Nodes)
+	}
+	return cidrs
+}
+
+func GetShootPodSpecificAllowedCIDRs(shoot *v1beta1.Shoot) []string {
+	cidrs := make([]string, 0)
+
+	if shoot.Spec.Networking == nil {
+		return cidrs
+	}
+	if shoot.Spec.Networking.Pods != nil {
+		cidrs = append(cidrs, *shoot.Spec.Networking.Pods)
+	}
+	return cidrs
+}

--- a/pkg/helper/suite_test.go
+++ b/pkg/helper/suite_test.go
@@ -1,0 +1,22 @@
+package helper
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestAPIs(t *testing.T) {
+	RegisterFailHandler(Fail)
+
+	RunSpecs(t, "EnvoyFilters Test Suite")
+}
+
+var _ = BeforeSuite(func() {
+
+})
+
+var _ = AfterSuite(func() {
+
+})

--- a/pkg/helper/suite_test.go
+++ b/pkg/helper/suite_test.go
@@ -10,13 +10,5 @@ import (
 func TestAPIs(t *testing.T) {
 	RegisterFailHandler(Fail)
 
-	RunSpecs(t, "EnvoyFilters Test Suite")
+	RunSpecs(t, "helper Test Suite")
 }
-
-var _ = BeforeSuite(func() {
-
-})
-
-var _ = AfterSuite(func() {
-
-})

--- a/pkg/webhook/webhook_test.go
+++ b/pkg/webhook/webhook_test.go
@@ -212,14 +212,8 @@ var _ = Describe("webhook unit test", func() {
 											},
 											{
 												"remote_ip": map[string]interface{}{
-													"address_prefix": "10.250.0.0",
+													"address_prefix": "100.250.0.0",
 													"prefix_len":     16,
-												},
-											},
-											{
-												"remote_ip": map[string]interface{}{
-													"address_prefix": "100.96.0.0",
-													"prefix_len":     11,
 												},
 											},
 											{
@@ -230,8 +224,14 @@ var _ = Describe("webhook unit test", func() {
 											},
 											{
 												"remote_ip": map[string]interface{}{
-													"address_prefix": "100.250.0.0",
+													"address_prefix": "10.250.0.0",
 													"prefix_len":     16,
+												},
+											},
+											{
+												"remote_ip": map[string]interface{}{
+													"address_prefix": "100.96.0.0",
+													"prefix_len":     11,
 												},
 											},
 										},
@@ -326,14 +326,8 @@ var _ = Describe("webhook unit test", func() {
 											},
 											{
 												"remote_ip": map[string]interface{}{
-													"address_prefix": "10.250.0.0",
+													"address_prefix": "100.250.0.0",
 													"prefix_len":     16,
-												},
-											},
-											{
-												"remote_ip": map[string]interface{}{
-													"address_prefix": "100.96.0.0",
-													"prefix_len":     11,
 												},
 											},
 											{
@@ -344,8 +338,14 @@ var _ = Describe("webhook unit test", func() {
 											},
 											{
 												"remote_ip": map[string]interface{}{
-													"address_prefix": "100.250.0.0",
+													"address_prefix": "10.250.0.0",
 													"prefix_len":     16,
+												},
+											},
+											{
+												"remote_ip": map[string]interface{}{
+													"address_prefix": "100.96.0.0",
+													"prefix_len":     11,
 												},
 											},
 											{


### PR DESCRIPTION
If there are multiple shoots with ACL on a shoot than the `acl-vpn` config contains wrong IPs. 


In the `pkg/controller/actuator.go` was a collection of `alwaysAllowedCIDRs` these contains:
```
shoot.Spec.Networking.Nodes
seed.Spec.Networks.Pods
seed.Spec.Networks.Nodes
egressIPfromShootNodes (from infrastructure object)
```

This IPs will be correctly used for `acl-api-shoot` but it will also used in `acl-vpn` for all shoots.

This results in only the last shoot which was reconciled is correct and is able to establish a new VPN connection. Already open VPN connection will stay open.

I separated the  `alwaysAllowedCIDRs` and `shootSpecificCIDRs` and get for all needed shoots this information during the reconcile.

Note: Ther should be definitely a test for that. I will add this with one of the PRs of the `HA-Seed` support, because I need to rework the tests anyway for that. 
