### PR TITLE
🐛 Fix Issues with Missing `Gateway` Objects on Hibernated Clusters

### DIFF
--- a/pkg/controller/actuator.go
+++ b/pkg/controller/actuator.go
@@ -549,7 +549,7 @@ func (a *actuator) getAllShootsWithACLExtension(
 				continue
 			}
 
-			istioNamespace = *extState.IstioNamespace
+			shootIstioNamespace = *extState.IstioNamespace
 		}
 
 		if istioNamespace != shootIstioNamespace {

--- a/pkg/controller/actuator_test.go
+++ b/pkg/controller/actuator_test.go
@@ -181,6 +181,52 @@ var _ = Describe("actuator test", func() {
 				ContainSubstring("5.6.7.8"),
 			))
 		})
+
+		It("should not fail when the Gateway resource can't be found for an extension other than the one being reconciled (e.g. for hibernated clusters)", func() {
+			// arrange
+			extSpec1 := ExtensionSpec{
+				Rule: &envoyfilters.ACLRule{
+					Cidrs:  []string{"1.2.3.4/24"},
+					Action: "ALLOW",
+					Type:   "remote_ip",
+				},
+			}
+			extSpecJSON1, err := json.Marshal(extSpec1)
+			Expect(err).To(BeNil())
+			ext1 := createNewExtension(shootNamespace1, extSpecJSON1)
+			Expect(ext1).To(Not(BeNil()))
+
+			// contents of the seconds extension don't matter, it just needs to exist
+			ext2 := createNewExtension(shootNamespace2, []byte("{}"))
+			Expect(ext2).To(Not(BeNil()))
+
+			// simulate a hibernated cluster by deleting the Gateway object
+			gw2 := &istionetworkingv1beta1.Gateway{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "kube-apiserver",
+					Namespace: shootNamespace2,
+				},
+			}
+			Expect(k8sClient.Delete(ctx, gw2)).To(Succeed())
+
+			// act (reconcile the existing extension)
+			Expect(a.Reconcile(ctx, logger, ext1)).To(Succeed())
+
+			// assert
+			envoyFilter := &istionetworkingClientGo.EnvoyFilter{}
+			Expect(k8sClient.Get(
+				ctx, types.NamespacedName{
+					Name:      "acl-vpn",
+					Namespace: istioNamespace1,
+				},
+				envoyFilter,
+			)).To(Succeed())
+
+			// we expect the filter to contain the settings from the first extension
+			Expect(envoyFilter.Spec.MarshalJSON()).To(And(
+				ContainSubstring("1.2.3.4"),
+			))
+		})
 	})
 
 	Describe("a shoot switching the istio namespace (e.g. when being migrated to HA)", func() {


### PR DESCRIPTION
**Problem:**

When hibernated clusters with enabled ACL extension are present on a `Seed`, and _another_ ACL extension is reconciled, the reconciliation pass collects all ACL `Extension` objects and tries to obtain `Gateway` objects for everyone of them. For hibernated clusters, these `Gateway` objects don't exist, leading to an error during the reconciliation.

**Solution:**

We refactor the actuator logic in the following way:

* When the actuator deals with a normal reconciliation, we first try to get the `istioNamespace` from the `Gateway` object. If this results in a `NotFound` error AND the `Shoot` is hibernated, we can't do anything, because we can't determine the `istioNamespace`. This means we `return nil`, skipping the reconciliation. If any other error occurs when trying to get the `istioNamespace` via the `Gateway`, we return it. (As this is a proper failure scenario for an ACL reconciliation.)
* When the actuator collects ACL information for every other cluster on the `Seed` (during construction of the VPN `EnvoyFilter` rules), we check for `NotFound` errors on looking up `Gateway` objects. If such an error occurred, we use the `istioNamespace` in the `extensionState` as a fallback. If it also doesn't contain an `istioNamespace`, the cluster in question has never been reconciled and its rules can be neglected for this pass.
* During deletion, we apply the same logic. If both the `Gateway` and the `istioNamespace` in the `extensionState` aren't available, we assume that the cluster has never been reconciled before and that we don't have to delete anything.

This change is accompanied by additional test cases:

* A hibernated cluster without a `Gateway` object doesn't lead to failures when another, non-hibernated cluster is reconciled.
* When deleting the ACL extension from a hibernated `Cluster` without a `Gateway` object (after the extension had been successfully reconciled at least once), the deletion succeeds, removing the `ManagedResource`.