### PR TITLE
Adapt acl extension for the generic infrastructure status field

### DIFF
--- a/pkg/helper/provider.go
+++ b/pkg/helper/provider.go
@@ -20,6 +20,10 @@ func GetProviderSpecificAllowedCIDRs(
 	infra *extensionsv1alpha1.Infrastructure,
 ) ([]string, error) {
 	cidrs := make([]string, 0)
+	if len(infra.Status.EgressCIDRs) > 0 {
+		cidrs = append(cidrs, infra.Status.EgressCIDRs...)
+		return cidrs, nil
+	}
 
 	//nolint:gocritic // Will likely be extended with other infra types in the future
 	switch infra.Spec.Type {

--- a/pkg/helper/provider_test.go
+++ b/pkg/helper/provider_test.go
@@ -32,6 +32,30 @@ var _ = Describe("provider Unit Tests", func() {
 				Expect(allowedCIDRs).To(Equal([]string{"a", "b"}))
 			})
 		})
+		When("there is an infrastructure object that supports the EgressCIDRs field", func() {
+			It("Should add the EgressCIDRs to the alwaysAllowedCIDRs slice and should not error", func() {
+				infra := &extensionsv1alpha1.Infrastructure{
+					Spec: extensionsv1alpha1.InfrastructureSpec{
+						DefaultSpec: extensionsv1alpha1.DefaultSpec{
+							Type: openstack.Type,
+						},
+					},
+					Status: extensionsv1alpha1.InfrastructureStatus{
+						EgressCIDRs: []string{
+							"10.9.8.7/32",
+							"1.1.1.0/24",
+						},
+					},
+				}
+
+				allowedCIDRs := []string{"a", "b"}
+				providerIPs, err := GetProviderSpecificAllowedCIDRs(infra)
+				Expect(err).To(Succeed())
+
+				allowedCIDRs = append(allowedCIDRs, providerIPs...)
+				Expect(allowedCIDRs).To(Equal([]string{"a", "b", "10.9.8.7/32", "1.1.1.0/24"}))
+			})
+		})
 		When("there is an infrastructure object of type 'openstack'", func() {
 			It("Should add the router IP to the alwaysAllowedCIDRs slice and should not error", func() {
 				infraStatusJSON, err := json.Marshal(&openstackv1alpha1.InfrastructureStatus{


### PR DESCRIPTION
Depend on https://github.com/stackitcloud/gardener-extension-acl/pull/38 (rebased upon that PR for latest gardener version). Only the last commit is the change actually introduced by this PR