### PR TITLE
Add validating admission webhook for acl extension

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,6 @@ REPO_ROOT                   := $(shell dirname $(realpath $(lastword $(MAKEFILE_
 HACK_DIR                    := $(REPO_ROOT)/hack
 VERSION                     := $(shell git describe --tag --always --dirty)
 TAG                         := $(VERSION)
-LD_FLAGS                    := "-w $(shell bash $(GARDENER_HACK_DIR)/get-build-ld-flags.sh "" $(REPO_ROOT)/VERSION "$(EXTENSION_PREFIX)")"
 LEADER_ELECTION             := false
 IGNORE_OPERATION_ANNOTATION := false
 
@@ -62,7 +61,6 @@ debug:
 .PHONY: start-admission
 start-admission:
 	@LEADER_ELECTION_NAMESPACE=garden go run \
-		-ldflags $(LD_FLAGS) \
 		./cmd/$(EXTENSION_PREFIX)-$(ADMISSION_NAME) \
 		--maxAllowedCIDRs=50 \
 		--webhook-config-server-host=0.0.0.0 \
@@ -75,13 +73,11 @@ start-admission:
 #################################################################
 
 PUSH ?= false
-images: export KO_DOCKER_REPO = $(REPO)/$(EXTENSION_PREFIX)-$(NAME)
 
 .PHONY: images
 images: $(KO)
 	KO_DOCKER_REPO=$(REPO)/$(EXTENSION_PREFIX)-$(NAME) $(KO) build --image-label org.opencontainers.image.source="https://github.com/stackitcloud/gardener-extension-acl" --sbom none -t $(TAG) --bare --platform linux/amd64,linux/arm64 --push=$(PUSH) ./cmd/gardener-extension-acl
-	KO_DOCKER_REPO=$(REPO)/$(EXTENSION_PREFIX)-$(ADMISSION_NAME) $(KO) build --image-label org.opencontainers.image.source="https://github.com/stackitcloud/gardener-extension-admission-acl" --sbom none -t $(TAG) --bare --platform linux/amd64,linux/arm64 --push=$(PUSH) ./cmd/gardener-extension-admission-acl
-
+	KO_DOCKER_REPO=$(REPO)/$(EXTENSION_PREFIX)-$(ADMISSION_NAME) $(KO) build --image-label org.opencontainers.image.source="https://github.com/stackitcloud/gardener-extension-acl" --sbom none -t $(TAG) --bare --platform linux/amd64,linux/arm64 --push=$(PUSH) ./cmd/gardener-extension-admission-acl
 
 #####################################################################
 # Rules for verification, formatting, linting, testing and cleaning #

--- a/charts/gardener-extension-admission-acl/Chart.yaml
+++ b/charts/gardener-extension-admission-acl/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+appVersion: "1.0"
+description: A Helm chart for the Gardener ACL extension.
+name: gardener-extension-admission-acl
+version: 0.1.0

--- a/charts/gardener-extension-admission-acl/charts/application/Chart.yaml
+++ b/charts/gardener-extension-admission-acl/charts/application/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+appVersion: "1.0"
+description: A Helm chart to deploy the gardener-extension-admission-acl application related resources
+name: application
+version: 0.1.0

--- a/charts/gardener-extension-admission-acl/charts/application/templates/_helpers.tpl
+++ b/charts/gardener-extension-admission-acl/charts/application/templates/_helpers.tpl
@@ -1,0 +1,23 @@
+{{- define "name" -}}
+gardener-extension-admission-acl
+{{- end -}}
+
+{{- define "labels.app.key" -}}
+app.kubernetes.io/name
+{{- end -}}
+{{- define "labels.app.value" -}}
+{{ include "name" . }}
+{{- end -}}
+
+{{- define "labels" -}}
+{{ include "labels.app.key" . }}: {{ include "labels.app.value" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{-  define "image" -}}
+  {{- if hasPrefix "sha256:" .tag }}
+  {{- printf "%s@%s" .repository .tag }}
+  {{- else }}
+  {{- printf "%s:%s" .repository .tag }}
+  {{- end }}
+{{- end }}

--- a/charts/gardener-extension-admission-acl/charts/application/templates/rbac.yaml
+++ b/charts/gardener-extension-admission-acl/charts/application/templates/rbac.yaml
@@ -1,0 +1,56 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "name" . }}
+  labels:
+{{ include "labels" . | indent 4 }}
+rules:
+- apiGroups:
+  - core.gardener.cloud
+  resources:
+  - shoots
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - admissionregistration.k8s.io
+  resources:
+  - validatingwebhookconfigurations
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - patch
+  - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "name" . }}
+  labels:
+{{ include "labels" . | indent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "name" . }}
+subjects:
+{{- if and .Values.global.virtualGarden.enabled .Values.global.virtualGarden.user.name }}
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: {{ .Values.global.virtualGarden.user.name  }}
+{{- else }}
+- kind: ServiceAccount
+  name: {{ include "name" . }}
+  namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/charts/gardener-extension-admission-acl/charts/application/templates/serviceaccount.yaml
+++ b/charts/gardener-extension-admission-acl/charts/application/templates/serviceaccount.yaml
@@ -1,0 +1,9 @@
+{{- if and .Values.global.virtualGarden.enabled ( not .Values.global.virtualGarden.user.name ) }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "name" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+{{ include "labels" . | indent 4 }}
+{{- end }}

--- a/charts/gardener-extension-admission-acl/charts/application/values.yaml
+++ b/charts/gardener-extension-admission-acl/charts/application/values.yaml
@@ -1,0 +1,1 @@
+../../values.yaml

--- a/charts/gardener-extension-admission-acl/charts/runtime/Chart.yaml
+++ b/charts/gardener-extension-admission-acl/charts/runtime/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+appVersion: "1.0"
+description: A Helm chart to deploy the gardener-extension-admission-acl runtime related resources
+name: runtime
+version: 0.1.0

--- a/charts/gardener-extension-admission-acl/charts/runtime/templates/_helpers.tpl
+++ b/charts/gardener-extension-admission-acl/charts/runtime/templates/_helpers.tpl
@@ -1,0 +1,27 @@
+{{- define "name" -}}
+gardener-extension-admission-acl
+{{- end -}}
+
+{{- define "labels.app.key" -}}
+app.kubernetes.io/name
+{{- end -}}
+{{- define "labels.app.value" -}}
+{{ include "name" . }}
+{{- end -}}
+
+{{- define "labels" -}}
+{{ include "labels.app.key" . }}: {{ include "labels.app.value" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{-  define "image" -}}
+  {{- if hasPrefix "sha256:" .tag }}
+  {{- printf "%s@%s" .repository .tag }}
+  {{- else }}
+  {{- printf "%s:%s" .repository .tag }}
+  {{- end }}
+{{- end }}
+
+{{- define "leaderelectionid" -}}
+gardener-extension-admission-acl
+{{- end -}}

--- a/charts/gardener-extension-admission-acl/charts/runtime/templates/deplyoment.yaml
+++ b/charts/gardener-extension-admission-acl/charts/runtime/templates/deplyoment.yaml
@@ -32,8 +32,7 @@ spec:
       - name: {{ include "name" . }}
         image: {{ include "image" .Values.global.image }}
         imagePullPolicy: {{ .Values.global.image.pullPolicy }}
-        command:
-        - /gardener-extension-admission-acl
+        args:
         - --webhook-config-server-port={{ .Values.global.webhookConfig.serverPort }}
         {{- if .Values.global.virtualGarden.enabled }}
         - --webhook-config-mode=url

--- a/charts/gardener-extension-admission-acl/charts/runtime/templates/deplyoment.yaml
+++ b/charts/gardener-extension-admission-acl/charts/runtime/templates/deplyoment.yaml
@@ -1,0 +1,137 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "name" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+{{ include "labels" . | indent 4 }}
+    high-availability-config.resources.gardener.cloud/type: server
+spec:
+  revisionHistoryLimit: 5
+  replicas: {{ .Values.global.replicaCount }}
+  selector:
+    matchLabels:
+{{ include "labels" . | indent 6 }}
+  template:
+    metadata:
+      annotations:
+        {{- if .Values.global.kubeconfig }}
+        checksum/gardener-extension-admission-acl-kubeconfig: {{ include (print $.Template.BasePath "/secret-kubeconfig.yaml") . | sha256sum }}
+        {{- end }}
+      labels:
+        networking.gardener.cloud/to-dns: allowed
+        networking.resources.gardener.cloud/to-virtual-garden-kube-apiserver-tcp-443: allowed
+        networking.gardener.cloud/to-runtime-apiserver: allowed
+{{ include "labels" . | indent 8 }}
+    spec:
+      serviceAccountName: {{ include "name" . }}
+      {{- if .Values.global.kubeconfig }}
+      automountServiceAccountToken: false
+      {{- end }}
+      containers:
+      - name: {{ include "name" . }}
+        image: {{ include "image" .Values.global.image }}
+        imagePullPolicy: {{ .Values.global.image.pullPolicy }}
+        command:
+        - /gardener-extension-admission-acl
+        - --webhook-config-server-port={{ .Values.global.webhookConfig.serverPort }}
+        {{- if .Values.global.virtualGarden.enabled }}
+        - --webhook-config-mode=url
+        - --webhook-config-url={{ printf "%s.%s" (include "name" .) (.Release.Namespace) }}
+        {{- else }}
+        - --webhook-config-mode=service
+        {{- end }}
+        - --webhook-config-namespace={{ .Release.Namespace }}
+        {{- if .Values.global.kubeconfig }}
+        - --kubeconfig=/etc/gardener-extension-admission-acl/kubeconfig/kubeconfig
+        {{- end }}
+        {{- if .Values.global.projectedKubeconfig }}
+        - --kubeconfig={{ required ".Values.global.projectedKubeconfig.baseMountPath is required" .Values.global.projectedKubeconfig.baseMountPath }}/kubeconfig
+        {{- end }}
+        - --health-bind-address=:{{ .Values.global.healthPort }}
+        - --leader-election-id={{ include "leaderelectionid" . }}
+        {{- if .Values.global.maxAllowedCIDRs }}
+        - --maxAllowedCIDRs={{ .Values.global.maxAllowedCIDRs }}
+        {{- end }}
+        env:
+        - name: LEADER_ELECTION_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        {{- if .Values.global.virtualGarden.enabled }}
+        - name: SOURCE_CLUSTER
+          value: enabled
+        {{- end }}
+        ports:
+        - name: webhook-server
+          containerPort: {{ .Values.global.webhookConfig.serverPort }}
+          protocol: TCP
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: {{ .Values.global.healthPort }}
+            scheme: HTTP
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: {{ .Values.global.healthPort }}
+            scheme: HTTP
+          initialDelaySeconds: 5
+{{- if .Values.global.resources }}
+        resources:
+{{ toYaml .Values.global.resources | nindent 10 }}
+{{- end }}
+        volumeMounts:
+        {{- if .Values.global.kubeconfig }}
+        - name: gardener-extension-admission-acl-kubeconfig
+          mountPath: /etc/gardener-extension-admission-acl/kubeconfig
+          readOnly: true
+        {{- end }}
+        {{- if .Values.global.serviceAccountTokenVolumeProjection.enabled }}
+        - name: service-account-token
+          mountPath: /var/run/secrets/projected/serviceaccount
+          readOnly: true
+        {{- end }}
+        {{- if .Values.global.projectedKubeconfig }}
+        - name: kubeconfig
+          mountPath: {{ required ".Values.global.projectedKubeconfig.baseMountPath is required" .Values.global.projectedKubeconfig.baseMountPath }}
+          readOnly: true
+        {{- end }}
+      volumes:
+      {{- if .Values.global.kubeconfig }}
+      - name: gardener-extension-admission-acl-kubeconfig
+        secret:
+          secretName: gardener-extension-admission-acl-kubeconfig
+          defaultMode: 420
+      {{- end }}
+      {{- if .Values.global.serviceAccountTokenVolumeProjection.enabled }}
+      - name: service-account-token
+        projected:
+          sources:
+          - serviceAccountToken:
+              path: token
+              expirationSeconds: {{ .Values.global.serviceAccountTokenVolumeProjection.expirationSeconds }}
+              {{- if .Values.global.serviceAccountTokenVolumeProjection.audience }}
+              audience: {{ .Values.global.serviceAccountTokenVolumeProjection.audience }}
+              {{- end }}
+      {{- end }}
+      {{- if .Values.global.projectedKubeconfig }}
+      - name: kubeconfig
+        projected:
+          defaultMode: 420
+          sources:
+          - secret:
+              items:
+              - key: kubeconfig
+                path: kubeconfig
+              name: {{ required ".Values.global.projectedKubeconfig.genericKubeconfigSecretName is required" .Values.global.projectedKubeconfig.genericKubeconfigSecretName }}
+              optional: false
+          - secret:
+              items:
+              - key: token
+                path: token
+              name: {{ required ".Values.global.projectedKubeconfig.tokenSecretName is required" .Values.global.projectedKubeconfig.tokenSecretName }}
+              optional: false
+      {{- end }}

--- a/charts/gardener-extension-admission-acl/charts/runtime/templates/poddisruptionbudget.yaml
+++ b/charts/gardener-extension-admission-acl/charts/runtime/templates/poddisruptionbudget.yaml
@@ -1,0 +1,12 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "name" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+{{ include "labels" . | indent 4 }}
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+{{ include "labels" . | indent 6 }}

--- a/charts/gardener-extension-admission-acl/charts/runtime/templates/rbac.yaml
+++ b/charts/gardener-extension-admission-acl/charts/runtime/templates/rbac.yaml
@@ -1,0 +1,62 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "name" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+{{ include "labels" . | indent 4 }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+  - list
+  - watch
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  resourceNames:
+  - {{ include "leaderelectionid" . }}
+  verbs:
+  - update
+  - get
+- apiGroups:
+  - ""
+  - events.k8s.io
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+  - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "name" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+{{ include "labels" . | indent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "name" . }}
+subjects:
+- kind: ServiceAccount
+  name: {{ include "name" . }}
+  namespace: {{ .Release.Namespace }}

--- a/charts/gardener-extension-admission-acl/charts/runtime/templates/secret-kubeconfig.yaml
+++ b/charts/gardener-extension-admission-acl/charts/runtime/templates/secret-kubeconfig.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.global.kubeconfig }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: gardener-extension-admission-acl-kubeconfig
+  namespace: "{{ .Release.Namespace }}"
+  labels:
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+type: Opaque
+data:
+  kubeconfig: {{ .Values.global.kubeconfig | b64enc }}
+{{- end }}

--- a/charts/gardener-extension-admission-acl/charts/runtime/templates/service.yaml
+++ b/charts/gardener-extension-admission-acl/charts/runtime/templates/service.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "name" . }}
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    networking.resources.gardener.cloud/from-all-webhook-targets-allowed-ports: '[{"protocol":"TCP","port":{{ .Values.global.webhookConfig.serverPort }}}]'
+    {{- if .Values.global.service.topologyAwareRouting.enabled }}
+    {{- if semverCompare ">= 1.27-0" .Capabilities.KubeVersion.GitVersion }}
+    service.kubernetes.io/topology-mode: "auto"
+    {{- else }}
+    service.kubernetes.io/topology-aware-hints: "auto"
+    {{- end }}
+    {{- end }}
+  labels:
+{{ include "labels" . | indent 4 }}
+    {{- if .Values.global.service.topologyAwareRouting.enabled }}
+    endpoint-slice-hints.resources.gardener.cloud/consider: "true"
+    {{- end }}
+spec:
+  type: ClusterIP
+  selector:
+{{ include "labels" . | indent 4 }}
+  ports:
+  - port: 443
+    protocol: TCP
+    targetPort: {{ .Values.global.webhookConfig.serverPort }}

--- a/charts/gardener-extension-admission-acl/charts/runtime/templates/serviceaccount.yaml
+++ b/charts/gardener-extension-admission-acl/charts/runtime/templates/serviceaccount.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "name" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+{{ include "labels" . | indent 4 }}

--- a/charts/gardener-extension-admission-acl/charts/runtime/templates/vpa.yaml
+++ b/charts/gardener-extension-admission-acl/charts/runtime/templates/vpa.yaml
@@ -1,0 +1,28 @@
+{{- if .Values.global.vpa.enabled}}
+apiVersion: "autoscaling.k8s.io/v1"
+kind: VerticalPodAutoscaler
+metadata:
+  name: {{ include "name" . }}-vpa
+  namespace: {{ .Release.Namespace }}
+spec:
+  {{- if .Values.global.vpa.resourcePolicy }}
+  resourcePolicy:
+    containerPolicies:
+    - containerName: '*'
+      {{- if .Values.global.vpa.resourcePolicy.minAllowed }}
+      minAllowed:
+        memory: {{ required ".Values.global.vpa.resourcePolicy.minAllowed.memory is required" .Values.global.vpa.resourcePolicy.minAllowed.memory }}
+      {{- end }}
+      {{- if .Values.global.vpa.resourcePolicy.maxAllowed }}
+      maxAllowed:
+        cpu: {{ required ".Values.global.vpa.resourcePolicy.maxAllowed.cpu is required" .Values.global.vpa.resourcePolicy.maxAllowed.cpu }}
+        memory: {{ required ".Values.global.vpa.resourcePolicy.maxAllowed.memory is required" .Values.global.vpa.resourcePolicy.maxAllowed.memory }}
+      {{- end }}
+  {{- end }}
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "name" . }}
+  updatePolicy:
+    updateMode: {{ .Values.global.vpa.updatePolicy.updateMode }}
+{{- end }}

--- a/charts/gardener-extension-admission-acl/charts/runtime/values.yaml
+++ b/charts/gardener-extension-admission-acl/charts/runtime/values.yaml
@@ -1,0 +1,1 @@
+../../values.yaml

--- a/charts/gardener-extension-admission-acl/templates/_helpers.tpl
+++ b/charts/gardener-extension-admission-acl/templates/_helpers.tpl
@@ -1,0 +1,23 @@
+{{- define "name" -}}
+gardener-extension-admission-acl
+{{- end -}}
+
+{{- define "labels.app.key" -}}
+app.kubernetes.io/name
+{{- end -}}
+{{- define "labels.app.value" -}}
+{{ include "name" . }}
+{{- end -}}
+
+{{- define "labels" -}}
+{{ include "labels.app.key" . }}: {{ include "labels.app.value" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{-  define "image" -}}
+  {{- if hasPrefix "sha256:" .tag }}
+  {{- printf "%s@%s" .repository .tag }}
+  {{- else }}
+  {{- printf "%s:%s" .repository .tag }}
+  {{- end }}
+{{- end }}

--- a/charts/gardener-extension-admission-acl/values.yaml
+++ b/charts/gardener-extension-admission-acl/values.yaml
@@ -2,10 +2,11 @@ global:
   virtualGarden:
     enabled: false
   image:
-    repository: ghcr.io/stackitcloud/gardener-extension-admission-acl:latest
+    repository: ghcr.io/stackitcloud/gardener-extension-admission-acl
     tag: latest
     pullPolicy: IfNotPresent
   replicaCount: 1
+  healthPort: 8081
   resources: {}
   vpa:
     enabled: true

--- a/charts/gardener-extension-admission-acl/values.yaml
+++ b/charts/gardener-extension-admission-acl/values.yaml
@@ -1,0 +1,29 @@
+global:
+  virtualGarden:
+    enabled: false
+  image:
+    repository: ghcr.io/stackitcloud/gardener-extension-admission-acl:latest
+    tag: latest
+    pullPolicy: IfNotPresent
+  replicaCount: 1
+  resources: {}
+  vpa:
+    enabled: true
+    resourcePolicy:
+      minAllowed:
+        cpu: 50m
+        memory: 64Mi
+    updatePolicy:
+      updateMode: "Auto"
+  webhookConfig:
+    serverPort: 10250
+  # Kubeconfig to the target cluster. In-cluster configuration will be used if not specified.
+  kubeconfig:
+  maxAllowedCIDRs: 50
+  serviceAccountTokenVolumeProjection:
+    enabled: false
+    expirationSeconds: 43200
+    audience: ""
+  service:
+    topologyAwareRouting:
+      enabled: false

--- a/cmd/gardener-extension-admission-acl/app/app.go
+++ b/cmd/gardener-extension-admission-acl/app/app.go
@@ -1,0 +1,172 @@
+package app
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	extensionscmdcontroller "github.com/gardener/gardener/extensions/pkg/controller/cmd"
+	"github.com/gardener/gardener/extensions/pkg/util"
+	extensionscmdwebhook "github.com/gardener/gardener/extensions/pkg/webhook/cmd"
+	"github.com/gardener/gardener/pkg/apis/core/install"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	gardenerhealthz "github.com/gardener/gardener/pkg/healthz"
+	"github.com/gardener/gardener/pkg/logger"
+	"github.com/spf13/cobra"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+	componentbaseconfig "k8s.io/component-base/config"
+	"k8s.io/component-base/version"
+	"k8s.io/component-base/version/verflag"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/cluster"
+	"sigs.k8s.io/controller-runtime/pkg/healthz"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+
+	admissioncmd "github.com/stackitcloud/gardener-extension-acl/pkg/admission/cmd"
+	"github.com/stackitcloud/gardener-extension-acl/pkg/admission/validator"
+)
+
+// ExtensionName is the name of the extension.
+const ExtensionName = "acl"
+
+// Name is a const for the name of this component.
+const Name = "gardener-extension-admission-acl"
+
+// NewControllerManagerCommand creates a new command for running a acl controller.
+func NewControllerManagerCommand(ctx context.Context) *cobra.Command {
+	var (
+		restOpts = &extensionscmdcontroller.RESTOptions{}
+		mgrOpts  = &extensionscmdcontroller.ManagerOptions{
+			LeaderElection:          true,
+			LeaderElectionID:        extensionscmdcontroller.LeaderElectionNameID(Name),
+			LeaderElectionNamespace: os.Getenv("LEADER_ELECTION_NAMESPACE"),
+			WebhookServerPort:       443,
+			HealthBindAddress:       ":8081",
+			WebhookCertDir:          "/tmp/admission-acl-cert",
+		}
+		// options for the webhook server
+		webhookServerOptions = &extensionscmdwebhook.ServerOptions{
+			Namespace: os.Getenv("WEBHOOK_CONFIG_NAMESPACE"),
+		}
+		webhookSwitches = admissioncmd.GardenWebhookSwitchOptions()
+		webhookOptions  = extensionscmdwebhook.NewAddToManagerOptions(
+			Name,
+			"",
+			nil,
+			webhookServerOptions,
+			webhookSwitches,
+		)
+		admissionOptions = &admissioncmd.AdmissionOptions{}
+
+		aggOption = extensionscmdcontroller.NewOptionAggregator(
+			restOpts,
+			mgrOpts,
+			webhookOptions,
+			admissionOptions,
+		)
+	)
+
+	cmd := &cobra.Command{
+		Use: fmt.Sprintf("admission-%s", ExtensionName),
+
+		RunE: func(cmd *cobra.Command, args []string) error {
+			verflag.PrintAndExitIfRequested()
+
+			log, err := logger.NewZapLogger(logger.InfoLevel, logger.FormatJSON)
+			if err != nil {
+				return fmt.Errorf("error instantiating zap logger: %w", err)
+			}
+			logf.SetLogger(log)
+
+			log.Info("Starting "+Name, "version", version.Get())
+
+			if err := aggOption.Complete(); err != nil {
+				return fmt.Errorf("error completing options: %w", err)
+			}
+			validator.DefaultAddOptions.MaxAllowedCIDRs = admissionOptions.Completed().MaxAllowedCIDRs
+
+			util.ApplyClientConnectionConfigurationToRESTConfig(&componentbaseconfig.ClientConnectionConfiguration{
+				QPS:   100.0,
+				Burst: 130,
+			}, restOpts.Completed().Config)
+
+			managerOptions := mgrOpts.Completed().Options()
+
+			// Operators can enable the source cluster option via SOURCE_CLUSTER environment variable.
+			// In-cluster config will be used if no SOURCE_KUBECONFIG is specified.
+			//
+			// The source cluster is for instance used by Gardener's certificate controller, to maintain certificate
+			// secrets in a different cluster ('runtime-garden') than the cluster where the webhook configurations
+			// are maintained ('virtual-garden').
+			var sourceClusterConfig *rest.Config
+			if sourceClusterEnabled := os.Getenv("SOURCE_CLUSTER"); sourceClusterEnabled != "" {
+				var err error
+				sourceClusterConfig, err = clientcmd.BuildConfigFromFlags("", os.Getenv("SOURCE_KUBECONFIG"))
+				if err != nil {
+					return err
+				}
+				managerOptions.LeaderElectionConfig = sourceClusterConfig
+			} else {
+				// Restrict the cache for secrets to the configured namespace to avoid the need for cluster-wide list/watch permissions.
+				managerOptions.Cache = cache.Options{
+					ByObject: map[client.Object]cache.ByObject{
+						&corev1.Secret{}: {Namespaces: map[string]cache.Config{webhookOptions.Server.Completed().Namespace: {}}},
+					},
+				}
+			}
+
+			mgr, err := manager.New(restOpts.Completed().Config, managerOptions)
+			if err != nil {
+				return fmt.Errorf("could not instantiate manager: %w", err)
+			}
+
+			install.Install(mgr.GetScheme())
+
+			var sourceCluster cluster.Cluster
+			if sourceClusterConfig != nil {
+				log.Info("Configuring source cluster option")
+				sourceCluster, err = cluster.New(sourceClusterConfig, func(opts *cluster.Options) {
+					opts.Logger = log
+					opts.Cache.DefaultNamespaces = map[string]cache.Config{v1beta1constants.GardenNamespace: {}}
+				})
+				if err != nil {
+					return err
+				}
+
+				if err := mgr.AddReadyzCheck("source-informer-sync", gardenerhealthz.NewCacheSyncHealthz(sourceCluster.GetCache())); err != nil {
+					return err
+				}
+
+				if err = mgr.Add(sourceCluster); err != nil {
+					return err
+				}
+			}
+
+			log.Info("Setting up webhook server")
+			if _, err := webhookOptions.Completed().AddToManager(ctx, mgr, sourceCluster); err != nil {
+				return err
+			}
+
+			if err := mgr.AddReadyzCheck("informer-sync", gardenerhealthz.NewCacheSyncHealthz(mgr.GetCache())); err != nil {
+				return fmt.Errorf("could not add readycheck for informers: %w", err)
+			}
+
+			if err := mgr.AddHealthzCheck("ping", healthz.Ping); err != nil {
+				return fmt.Errorf("could not add healthcheck: %w", err)
+			}
+
+			if err := mgr.AddReadyzCheck("webhook-server", mgr.GetWebhookServer().StartedChecker()); err != nil {
+				return fmt.Errorf("could not add readycheck of webhook to manager: %w", err)
+			}
+
+			return mgr.Start(ctx)
+		},
+	}
+	aggOption.AddFlags(cmd.Flags())
+
+	return cmd
+}

--- a/cmd/gardener-extension-admission-acl/main.go
+++ b/cmd/gardener-extension-admission-acl/main.go
@@ -1,0 +1,20 @@
+package main
+
+import (
+	"os"
+
+	"github.com/gardener/gardener/pkg/logger"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
+
+	"github.com/stackitcloud/gardener-extension-acl/cmd/gardener-extension-admission-acl/app"
+)
+
+func main() {
+	logf.SetLogger(logger.MustNewZapLogger(logger.InfoLevel, logger.FormatJSON))
+
+	if err := app.NewControllerManagerCommand(signals.SetupSignalHandler()).Execute(); err != nil {
+		logf.Log.Error(err, "Error executing the main controller command")
+		os.Exit(1)
+	}
+}

--- a/pkg/admission/cmd/config.go
+++ b/pkg/admission/cmd/config.go
@@ -1,0 +1,33 @@
+package cmd
+
+import (
+	"github.com/spf13/pflag"
+
+	controllerconfig "github.com/stackitcloud/gardener-extension-acl/pkg/controller/config"
+)
+
+// AdmissionOptions are command line options that can be set for admission controller.
+type AdmissionOptions struct {
+	// MaxAllowedCIDRs is the maximum number of allowed CIDRs per cluster
+	MaxAllowedCIDRs int
+}
+
+// AddFlags implements Flagger.AddFlags.
+func (a *AdmissionOptions) AddFlags(fs *pflag.FlagSet) {
+	fs.IntVar(&a.MaxAllowedCIDRs, "maxAllowedCIDRs", 50, "maximum number of allowed CIDRs per cluster")
+}
+
+// Complete implements Completer.Complete.
+func (a *AdmissionOptions) Complete() error {
+	return nil
+}
+
+// Completed returns the completed Config. Only call this if `Complete` was successful.
+func (a *AdmissionOptions) Completed() *AdmissionOptions {
+	return a
+}
+
+// Apply sets the values of this Config in the given config.ControllerConfiguration.
+func (a *AdmissionOptions) Apply(config *controllerconfig.Config) {
+	config.MaxAllowedCIDRs = a.MaxAllowedCIDRs
+}

--- a/pkg/admission/cmd/options.go
+++ b/pkg/admission/cmd/options.go
@@ -1,0 +1,14 @@
+package cmd
+
+import (
+	extensionscmdwebhook "github.com/gardener/gardener/extensions/pkg/webhook/cmd"
+
+	"github.com/stackitcloud/gardener-extension-acl/pkg/admission/validator"
+)
+
+// GardenWebhookSwitchOptions are the extensionscmdwebhook.SwitchOptions for the admission webhooks.
+func GardenWebhookSwitchOptions() *extensionscmdwebhook.SwitchOptions {
+	return extensionscmdwebhook.NewSwitchOptions(
+		extensionscmdwebhook.Switch(validator.Name, validator.New),
+	)
+}

--- a/pkg/admission/validator/shoot.go
+++ b/pkg/admission/validator/shoot.go
@@ -1,0 +1,102 @@
+package validator
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	extensionswebhook "github.com/gardener/gardener/extensions/pkg/webhook"
+	"github.com/gardener/gardener/pkg/apis/core"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+
+	"github.com/stackitcloud/gardener-extension-acl/pkg/webhook"
+)
+
+// NewShootValidator returns a new instance of a shoot validator.
+func NewShootValidator(mgr manager.Manager) extensionswebhook.Validator {
+	return &shoot{
+		client: mgr.GetClient(),
+	}
+}
+
+const (
+	ruleKey  = "rule"
+	cidrsKey = "cidrs"
+)
+
+// DefaultAddOptions are the default options to apply when adding the webhook to the manager.
+var DefaultAddOptions = AddOptions{}
+
+// AddOptions are options to apply when adding the webhook to the manager.
+type AddOptions struct {
+	MaxAllowedCIDRs int
+}
+
+type shoot struct {
+	client client.Client
+}
+
+// Validate validates the given shoot object.
+func (s *shoot) Validate(ctx context.Context, new, old client.Object) error {
+	shoot, ok := new.(*core.Shoot)
+	if !ok {
+		return fmt.Errorf("wrong object type %T", new)
+	}
+	if old != nil {
+		return s.validateShootUpdate(ctx, shoot)
+	}
+	return s.validateShootCreation(ctx, shoot)
+}
+func (s *shoot) validateShoot(_ context.Context, shoot *core.Shoot) error {
+	aclExtension := s.findExtension(shoot)
+	if aclExtension == nil {
+		return nil
+	}
+
+	aclRules, err := s.decodeAclExtension(aclExtension.ProviderConfig)
+	if err != nil {
+		return err
+	}
+
+	if aclRules != nil {
+		if rule, ok := aclRules[ruleKey].(map[string]interface{}); ok {
+			if cidrs, ok := rule[cidrsKey].([]interface{}); ok {
+				if len(cidrs) > DefaultAddOptions.MaxAllowedCIDRs {
+					fldPath := field.NewPath("spec", "extensions", "providerConfig", "rule", "cidrs")
+					return field.TooMany(fldPath, len(cidrs), DefaultAddOptions.MaxAllowedCIDRs)
+				}
+			}
+		}
+	}
+	return nil
+}
+func (s *shoot) validateShootUpdate(ctx context.Context, shoot *core.Shoot) error {
+	return s.validateShoot(ctx, shoot)
+}
+func (s *shoot) validateShootCreation(ctx context.Context, shoot *core.Shoot) error {
+	return s.validateShoot(ctx, shoot)
+}
+
+// findExtension returns acl extension.
+func (s *shoot) findExtension(shoot *core.Shoot) *core.Extension {
+	for i, ext := range shoot.Spec.Extensions {
+		if ext.Type == webhook.ExtensionName {
+			return &shoot.Spec.Extensions[i]
+		}
+	}
+	return nil
+}
+
+func (s *shoot) decodeAclExtension(aclExt *runtime.RawExtension) (map[string]interface{}, error) {
+	var aclRules map[string]interface{}
+	if aclExt == nil || aclExt.Raw == nil {
+		return map[string]interface{}{}, nil
+	}
+	if err := json.Unmarshal(aclExt.Raw, &aclRules); err != nil {
+		return nil, err
+	}
+	return aclRules, nil
+}

--- a/pkg/admission/validator/shoot_test.go
+++ b/pkg/admission/validator/shoot_test.go
@@ -1,0 +1,100 @@
+package validator_test
+
+import (
+	"context"
+
+	extensionswebhook "github.com/gardener/gardener/extensions/pkg/webhook"
+	"github.com/gardener/gardener/pkg/apis/core"
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	mockclient "github.com/gardener/gardener/pkg/mock/controller-runtime/client"
+	mockmanager "github.com/gardener/gardener/pkg/mock/controller-runtime/manager"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gstruct"
+	"go.uber.org/mock/gomock"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+
+	"github.com/stackitcloud/gardener-extension-acl/pkg/admission/validator"
+)
+
+var _ = Describe("Shoot validator", func() {
+	Describe("#Validate", func() {
+		const namespace = "garden-dev"
+
+		var (
+			shootValidator extensionswebhook.Validator
+
+			ctrl  *gomock.Controller
+			mgr   *mockmanager.MockManager
+			c     *mockclient.MockClient
+			shoot *core.Shoot
+
+			ctx = context.TODO()
+		)
+
+		BeforeEach(func() {
+			ctrl = gomock.NewController(GinkgoT())
+
+			scheme := runtime.NewScheme()
+			Expect(gardencorev1beta1.AddToScheme(scheme)).To(Succeed())
+
+			c = mockclient.NewMockClient(ctrl)
+			mgr = mockmanager.NewMockManager(ctrl)
+
+			mgr.EXPECT().GetClient().Return(c)
+
+			shootValidator = validator.NewShootValidator(mgr)
+			validator.DefaultAddOptions.MaxAllowedCIDRs = 5
+
+			shoot = &core.Shoot{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: namespace,
+				},
+				Spec: core.ShootSpec{
+					Extensions: []core.Extension{
+						{
+							Type:           "acl",
+							ProviderConfig: &runtime.RawExtension{Raw: []byte(`{"rule":{"action":"ALLOW","cidrs":["1.2.3.4/24","10.250.0.0/16"],"type":"remote_ip"}}`)},
+						},
+					},
+				},
+			}
+		})
+
+		Context("Shoot creation (old is nil)", func() {
+			It("should succeed if number of specified cidrs in acl extension is below maximum", func() {
+				Expect(shootValidator.Validate(ctx, shoot, nil)).To(Succeed())
+			})
+
+			It("should return err if to many cidrs are specified in acl extension", func() {
+				shoot.Spec.Extensions[0].ProviderConfig = &runtime.RawExtension{Raw: []byte(`{"rule":{"action":"ALLOW","cidrs":["1.2.3.4/24","10.250.0.0/16","208.127.57.6/32","165.1.187.201/32","165.1.187.202/32","165.1.187.203/32","165.1.187.207/32","165.1.187.208/32"],"type":"remote_ip"}}`)}
+				err := shootValidator.Validate(ctx, shoot, nil)
+				Expect(err).To(PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeTooMany),
+					"Field": Equal("spec.extensions.providerConfig.rule.cidrs"),
+				})))
+			})
+		})
+
+		Context("Shoot update", func() {
+			It("should return err if to many cidrs are specified in acl extension", func() {
+				newShoot := shoot
+				newShoot.Spec.Extensions[0].ProviderConfig = &runtime.RawExtension{Raw: []byte(`{"rule":{"action":"ALLOW","cidrs":["1.2.3.4/24","10.250.0.0/16","208.127.57.6/32","165.1.187.201/32","165.1.187.202/32","165.1.187.203/32","165.1.187.207/32","165.1.187.208/32"],"type":"remote_ip"}}`)}
+				err := shootValidator.Validate(ctx, newShoot, shoot)
+				Expect(err).To(PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeTooMany),
+					"Field": Equal("spec.extensions.providerConfig.rule.cidrs"),
+				})))
+			})
+
+			It("should succeed if number of specified cidrs in acl extension is below maximum", func() {
+				newShoot := shoot
+				newShoot.Spec.Extensions[0].ProviderConfig = &runtime.RawExtension{Raw: []byte(`{"rule":{"action":"ALLOW","cidrs":["1.2.3.4/24","10.250.0.0/16","208.127.57.6/32","165.1.187.201/32","165.1.187.202/32"],"type":"remote_ip"}}`)}
+				Expect(shootValidator.Validate(ctx, newShoot, shoot)).To(Succeed())
+			})
+		})
+	})
+})

--- a/pkg/admission/validator/validator_suite_test.go
+++ b/pkg/admission/validator/validator_suite_test.go
@@ -1,0 +1,13 @@
+package validator_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestValidator(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Validator Suite")
+}

--- a/pkg/admission/validator/webhook.go
+++ b/pkg/admission/validator/webhook.go
@@ -1,0 +1,33 @@
+package validator
+
+import (
+	extensionswebhook "github.com/gardener/gardener/extensions/pkg/webhook"
+	"github.com/gardener/gardener/pkg/apis/core"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+)
+
+const (
+	// Name is a name for a validation webhook.
+	Name = "validator"
+)
+
+var logger = log.Log.WithName("acl-validator-webhook")
+
+// New creates a new webhook that validates Shoot resources.
+func New(mgr manager.Manager) (*extensionswebhook.Webhook, error) {
+	logger.Info("Setting up webhook", "name", Name)
+	return extensionswebhook.New(mgr, extensionswebhook.Args{
+		Provider: "acl",
+		Name:     Name,
+		Path:     "/webhooks/validate",
+		Validators: map[extensionswebhook.Validator][]extensionswebhook.Type{
+			NewShootValidator(mgr): {{Obj: &core.Shoot{}}},
+		},
+		Target: extensionswebhook.TargetSeed,
+		ObjectSelector: &metav1.LabelSelector{
+			MatchLabels: map[string]string{"extensions.extensions.gardener.cloud/acl": "true"},
+		},
+	})
+}

--- a/pkg/controller/actuator.go
+++ b/pkg/controller/actuator.go
@@ -50,6 +50,7 @@ import (
 	"github.com/stackitcloud/gardener-extension-acl/charts"
 	"github.com/stackitcloud/gardener-extension-acl/pkg/controller/config"
 	"github.com/stackitcloud/gardener-extension-acl/pkg/envoyfilters"
+	"github.com/stackitcloud/gardener-extension-acl/pkg/extensionspec"
 	"github.com/stackitcloud/gardener-extension-acl/pkg/helper"
 	"github.com/stackitcloud/gardener-extension-acl/pkg/imagevector"
 )
@@ -106,12 +107,6 @@ type actuator struct {
 	extensionConfig config.Config
 }
 
-// ExtensionSpec is the content of the ProviderConfig of the acl extension object
-type ExtensionSpec struct {
-	// Rule contain the user-defined Access Control Rule
-	Rule *envoyfilters.ACLRule `json:"rule"`
-}
-
 // Reconcile the Extension resource.
 //
 //nolint:gocyclo // this is the main reconcile loop
@@ -121,7 +116,7 @@ func (a *actuator) Reconcile(ctx context.Context, log logr.Logger, ex *extension
 		return err
 	}
 
-	extSpec := &ExtensionSpec{}
+	extSpec := &extensionspec.ExtensionSpec{}
 	if ex.Spec.ProviderConfig != nil && ex.Spec.ProviderConfig.Raw != nil {
 		if err := json.Unmarshal(ex.Spec.ProviderConfig.Raw, &extSpec); err != nil {
 			return err
@@ -220,7 +215,7 @@ func (a *actuator) Reconcile(ctx context.Context, log logr.Logger, ex *extension
 
 // ValidateExtensionSpec checks if the ExtensionSpec exists, and if its action,
 // type and CIDRs are valid.
-func ValidateExtensionSpec(spec *ExtensionSpec) error {
+func ValidateExtensionSpec(spec *extensionspec.ExtensionSpec) error {
 	rule := spec.Rule
 
 	if rule == nil {
@@ -364,7 +359,7 @@ func (a *actuator) createSeedResources(
 	ctx context.Context,
 	log logr.Logger,
 	namespace string,
-	spec *ExtensionSpec,
+	spec *extensionspec.ExtensionSpec,
 	cluster *controller.Cluster,
 	hosts []string,
 	shootSpecificCIRDs []string,
@@ -564,7 +559,7 @@ func (a *actuator) getAllShootsWithACLExtension(
 			istioLabels = shootIstioLabels
 		}
 
-		extSpec := &ExtensionSpec{}
+		extSpec := &extensionspec.ExtensionSpec{}
 		if ex.Spec.ProviderConfig != nil && ex.Spec.ProviderConfig.Raw != nil {
 			if err := json.Unmarshal(ex.Spec.ProviderConfig.Raw, &extSpec); err != nil {
 				return nil, nil, err

--- a/pkg/controller/actuator_test.go
+++ b/pkg/controller/actuator_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/stackitcloud/gardener-extension-acl/pkg/controller/config"
 	"github.com/stackitcloud/gardener-extension-acl/pkg/envoyfilters"
+	"github.com/stackitcloud/gardener-extension-acl/pkg/extensionspec"
 )
 
 var _ = Describe("actuator test", func() {
@@ -50,7 +51,7 @@ var _ = Describe("actuator test", func() {
 
 	Describe("reconciliation of an ACL extension object", func() {
 		It("should create an acl-vpn EnvoyFilter object with the correct contents", func() {
-			extSpec := ExtensionSpec{
+			extSpec := extensionspec.ExtensionSpec{
 				Rule: &envoyfilters.ACLRule{
 					Cidrs:  []string{"1.2.3.4/24"},
 					Action: "ALLOW",
@@ -70,7 +71,7 @@ var _ = Describe("actuator test", func() {
 		})
 
 		It("should create managed resource for acl-api-shoot EnvoyFilter object", func() {
-			extSpec := ExtensionSpec{
+			extSpec := extensionspec.ExtensionSpec{
 				Rule: &envoyfilters.ACLRule{
 					Cidrs:  []string{"1.2.3.4/24"},
 					Action: "ALLOW",
@@ -93,7 +94,7 @@ var _ = Describe("actuator test", func() {
 
 		It("should record the last seen istio namespace in the status of the extension object", func() {
 			// arrange
-			extSpec := ExtensionSpec{
+			extSpec := extensionspec.ExtensionSpec{
 				Rule: &envoyfilters.ACLRule{
 					Cidrs:  []string{"1.2.3.4/24"},
 					Action: "ALLOW",
@@ -137,7 +138,7 @@ var _ = Describe("actuator test", func() {
 
 		It("should create an acl-vpn EnvoyFilter object with the correct contents (from both extensions)", func() {
 			// arrange
-			extSpec1 := ExtensionSpec{
+			extSpec1 := extensionspec.ExtensionSpec{
 				Rule: &envoyfilters.ACLRule{
 					Cidrs:  []string{"1.2.3.4/24"},
 					Action: "ALLOW",
@@ -149,7 +150,7 @@ var _ = Describe("actuator test", func() {
 			ext1 := createNewExtension(shootNamespace1, extSpecJSON1)
 			Expect(ext1).To(Not(BeNil()))
 
-			extSpec2 := ExtensionSpec{
+			extSpec2 := extensionspec.ExtensionSpec{
 				Rule: &envoyfilters.ACLRule{
 					Cidrs:  []string{"5.6.7.8/24"},
 					Action: "ALLOW",
@@ -184,7 +185,7 @@ var _ = Describe("actuator test", func() {
 
 		It("should not fail when the Gateway resource can't be found for an extension other than the one being reconciled (e.g. for hibernated clusters)", func() {
 			// arrange
-			extSpec1 := ExtensionSpec{
+			extSpec1 := extensionspec.ExtensionSpec{
 				Rule: &envoyfilters.ACLRule{
 					Cidrs:  []string{"1.2.3.4/24"},
 					Action: "ALLOW",
@@ -233,7 +234,7 @@ var _ = Describe("actuator test", func() {
 		It("should modify the EnvoyFilter objects accordingly", func() {
 			By("1) creating the EnvoyFilter object correctly in the ORIGINAL namespace")
 			// arrange
-			extSpec := ExtensionSpec{
+			extSpec := extensionspec.ExtensionSpec{
 				Rule: &envoyfilters.ACLRule{
 					Cidrs:  []string{"1.2.3.4/24"},
 					Action: "ALLOW",
@@ -298,7 +299,7 @@ var _ = Describe("actuator test", func() {
 	Describe("deletion of a hibernated cluster (no Gateway resource exists)", func() {
 		It("should properly clean up according ManagedResource", func() {
 			// arrange
-			extSpec := ExtensionSpec{
+			extSpec := extensionspec.ExtensionSpec{
 				Rule: &envoyfilters.ACLRule{
 					Cidrs:  []string{"1.2.3.4/24"},
 					Action: "ALLOW",
@@ -400,7 +401,7 @@ var _ = Describe("actuator unit test", func() {
 	Describe("ValidateExtensionSpec", func() {
 		When("there is an extension resource with one valid rule", func() {
 			It("Should not return an error", func() {
-				extSpec := &ExtensionSpec{}
+				extSpec := &extensionspec.ExtensionSpec{}
 				addRuleToSpec(extSpec, "DENY", "source_ip", "0.0.0.0/0")
 
 				Expect(ValidateExtensionSpec(extSpec)).To(Succeed())
@@ -409,14 +410,14 @@ var _ = Describe("actuator unit test", func() {
 
 		When("there is an extension resource without rules", func() {
 			It("Should return an error", func() {
-				extSpec := &ExtensionSpec{}
+				extSpec := &extensionspec.ExtensionSpec{}
 				Expect(ValidateExtensionSpec(extSpec)).To(Equal(ErrSpecRule))
 			})
 		})
 
 		When("there is an extension resource with a rule with invalid rule type", func() {
 			It("Should return the correct error", func() {
-				extSpec := &ExtensionSpec{}
+				extSpec := &extensionspec.ExtensionSpec{}
 				addRuleToSpec(extSpec, "DENY", "nonexistent", "0.0.0.0/0")
 
 				Expect(ValidateExtensionSpec(extSpec)).To(Equal(ErrSpecType))
@@ -425,7 +426,7 @@ var _ = Describe("actuator unit test", func() {
 
 		When("there is an extension resource with a rule with invalid rule action", func() {
 			It("Should return the correct error", func() {
-				extSpec := &ExtensionSpec{}
+				extSpec := &extensionspec.ExtensionSpec{}
 				addRuleToSpec(extSpec, "NONEXISTENT", "remote_ip", "0.0.0.0/0")
 
 				Expect(ValidateExtensionSpec(extSpec)).To(Equal(ErrSpecAction))
@@ -434,7 +435,7 @@ var _ = Describe("actuator unit test", func() {
 
 		When("there is an extension resource with CIDR", func() {
 			It("Should return the correct error", func() {
-				extSpec := &ExtensionSpec{}
+				extSpec := &extensionspec.ExtensionSpec{}
 				addRuleToSpec(extSpec, "DENY", "remote_ip", "n0n3x1st3/nt")
 
 				// we're not testing for a specific error, as they come from the
@@ -445,7 +446,7 @@ var _ = Describe("actuator unit test", func() {
 
 		When("there is an extension resource with a rule without CIDR", func() {
 			It("Should return the correct error", func() {
-				extSpec := &ExtensionSpec{}
+				extSpec := &extensionspec.ExtensionSpec{}
 
 				extSpec.Rule = &envoyfilters.ACLRule{
 					Action: "DENY",
@@ -460,7 +461,7 @@ var _ = Describe("actuator unit test", func() {
 
 		When("there is an extension resource with a rule with invalid CIDR", func() {
 			It("Should return the correct error", func() {
-				extSpec := &ExtensionSpec{}
+				extSpec := &extensionspec.ExtensionSpec{}
 				addRuleToSpec(extSpec, "DENY", "remote_ip", "n0n3x1st3/nt")
 
 				// we're not testing for a specific error, as they come from the
@@ -481,7 +482,7 @@ func getNewActuator() *actuator {
 	}
 }
 
-func addRuleToSpec(extSpec *ExtensionSpec, action, ruleType, cidr string) {
+func addRuleToSpec(extSpec *extensionspec.ExtensionSpec, action, ruleType, cidr string) {
 	extSpec.Rule = &envoyfilters.ACLRule{
 		Cidrs: []string{
 			cidr,

--- a/pkg/controller/config/config.go
+++ b/pkg/controller/config/config.go
@@ -21,4 +21,6 @@ type Config struct {
 	ChartPath string
 	// AdditionalAllowedCIDRs additional allowed cidrs that will be added to the list of allowed cidrs.
 	AdditionalAllowedCIDRs []string
+	// MaxAllowedCIDRs is the maximum number of allowed CIDRs per cluster
+	MaxAllowedCIDRs int
 }

--- a/pkg/extensionspec/extensionspec.go
+++ b/pkg/extensionspec/extensionspec.go
@@ -1,0 +1,9 @@
+package extensionspec
+
+import "github.com/stackitcloud/gardener-extension-acl/pkg/envoyfilters"
+
+// ExtensionSpec is the content of the ProviderConfig of the acl extension object
+type ExtensionSpec struct {
+	// Rule contain the user-defined Access Control Rule
+	Rule *envoyfilters.ACLRule `json:"rule"`
+}

--- a/pkg/webhook/suite_test.go
+++ b/pkg/webhook/suite_test.go
@@ -11,6 +11,7 @@ import (
 	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/stackitcloud/gardener-extension-acl/pkg/extensionspec"
 	istionetworkingClientGo "istio.io/client-go/pkg/apis/networking/v1alpha3"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
@@ -22,8 +23,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
-
-	"github.com/stackitcloud/gardener-extension-acl/pkg/controller"
 )
 
 var cfg *rest.Config
@@ -108,7 +107,7 @@ func deleteNamespace(name string) {
 	Expect(k8sClient.Delete(ctx, namespace)).ShouldNot(HaveOccurred())
 }
 
-func getNewExtension(namespace string, spec controller.ExtensionSpec) *extensionsv1alpha1.Extension {
+func getNewExtension(namespace string, spec extensionspec.ExtensionSpec) *extensionsv1alpha1.Extension {
 	rawSpec, err := json.Marshal(spec)
 	Expect(err).ToNot(HaveOccurred())
 

--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/stackitcloud/gardener-extension-acl/pkg/controller"
 	"github.com/stackitcloud/gardener-extension-acl/pkg/envoyfilters"
+	"github.com/stackitcloud/gardener-extension-acl/pkg/extensionspec"
 	"github.com/stackitcloud/gardener-extension-acl/pkg/helper"
 )
 
@@ -80,7 +81,7 @@ func (e *EnvoyFilterWebhook) createAdmissionResponse(
 		}
 	}
 
-	extSpec := &controller.ExtensionSpec{}
+	extSpec := &extensionspec.ExtensionSpec{}
 	if err := json.Unmarshal(aclExtension.Spec.ProviderConfig.Raw, extSpec); err != nil {
 		return admission.Errored(http.StatusInternalServerError, err)
 	}

--- a/pkg/webhook/webhook_test.go
+++ b/pkg/webhook/webhook_test.go
@@ -20,8 +20,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
-	"github.com/stackitcloud/gardener-extension-acl/pkg/controller"
 	"github.com/stackitcloud/gardener-extension-acl/pkg/envoyfilters"
+	"github.com/stackitcloud/gardener-extension-acl/pkg/extensionspec"
 )
 
 var _ = Describe("webhook unit test", func() {
@@ -526,13 +526,13 @@ func getNewInfrastructure(
 	}
 }
 
-func getExtensionSpec() *controller.ExtensionSpec {
-	return &controller.ExtensionSpec{
+func getExtensionSpec() *extensionspec.ExtensionSpec {
+	return &extensionspec.ExtensionSpec{
 		Rule: &envoyfilters.ACLRule{},
 	}
 }
 
-func addRuleToSpec(extSpec *controller.ExtensionSpec, action, ruleType, cidr string) {
+func addRuleToSpec(extSpec *extensionspec.ExtensionSpec, action, ruleType, cidr string) {
 	extSpec.Rule = &envoyfilters.ACLRule{
 		Cidrs: []string{
 			cidr,

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -8,6 +8,9 @@ build:
     - image: ghcr.io/stackitcloud/gardener-extension-acl
       ko:
         main: ./cmd/gardener-extension-acl
+    - image: ghcr.io/stackitcloud/gardener-extension-admission-acl
+      ko:
+        main: ./cmd/gardener-extension-admission-acl
 resourceSelector:
   allow:
     # instruct skaffold to inject the built image reference into the image field in our ControllerDeployment
@@ -19,3 +22,7 @@ manifests:
       - ./deploy/extension/local
 deploy:
   kubectl: {}
+  helm:
+    releases:
+      - name: gardener-extension-admission-acl
+        chartPath: ./charts/gardener-extension-admission-acl


### PR DESCRIPTION
Currently there is no limit how many CIDR ranges can be specified in the `shoot.yaml` file for the acl extension. As all CIDR ranges from all shoot clusters accumulate in the `acl-vpn` envoy filter and the size of the kubernetes api-resources is limited it is desirable to limit the number of specified CIDR ranges per shoot. 

This PR adds an admission webhook to the [gardener-extension-acl](https://github.com/stackitcloud/gardener-extension-acl) which limits the number of specified CIDR ranges in the `shoot.yaml` file for the acl-extension to `--maxAllowedCIDRs` value.