### PR TITLE
Fix webhook for shoots with legacy technical ID

### DIFF
--- a/pkg/webhook/webhook_test.go
+++ b/pkg/webhook/webhook_test.go
@@ -99,27 +99,29 @@ var _ = Describe("webhook unit test", func() {
 			})
 		})
 
-		When("the shoot uses the legacy technical ID format 'shoot-'", func() {
-			It("should not exit early and handle the EnvoyFilter", func() {
-				df, dfJSON := getEnvoyFilterFromFile("shoot-foo-bar")
-
-				ar := e.createAdmissionResponse(context.Background(), df, dfJSON)
-
-				Expect(ar.Allowed).To(BeTrue())
-				Expect(ar.Result.Message).To(ContainSubstring("not enabled for shoot"))
-				Expect(ar.Patch).To(BeEmpty())
-			})
-		})
-
 		When("there is no extension", func() {
-			It("issues no patch for the EnvoyFilter", func() {
-				df, dfJSON := getEnvoyFilterFromFile(namespace)
+			When("the shoot uses the legacy technical ID format 'shoot-'", func() {
+				It("issues no patch for the EnvoyFilter", func() {
+					df, dfJSON := getEnvoyFilterFromFile("shoot-foo-bar")
 
-				ar := e.createAdmissionResponse(context.Background(), df, dfJSON)
+					ar := e.createAdmissionResponse(context.Background(), df, dfJSON)
 
-				Expect(ar.Allowed).To(BeTrue())
-				Expect(ar.Result.Message).To(ContainSubstring("not enabled for shoot"))
-				Expect(ar.Patch).To(BeEmpty())
+					Expect(ar.Allowed).To(BeTrue())
+					Expect(ar.Result.Message).To(ContainSubstring("not enabled for shoot"))
+					Expect(ar.Patch).To(BeEmpty())
+				})
+			})
+
+			When("the shoot uses the current technical ID format 'shoot--'", func() {
+				It("issues no patch for the EnvoyFilter", func() {
+					df, dfJSON := getEnvoyFilterFromFile(namespace)
+
+					ar := e.createAdmissionResponse(context.Background(), df, dfJSON)
+
+					Expect(ar.Allowed).To(BeTrue())
+					Expect(ar.Result.Message).To(ContainSubstring("not enabled for shoot"))
+					Expect(ar.Patch).To(BeEmpty())
+				})
 			})
 		})
 

--- a/pkg/webhook/webhook_test.go
+++ b/pkg/webhook/webhook_test.go
@@ -87,25 +87,39 @@ var _ = Describe("webhook unit test", func() {
 	})
 
 	Describe("createAdmissionResponse", func() {
-		When("the name of the EnvoyFilter doesn't start with 'shoot--'", func() {
-			It("issues no patch for the EnvoyyFilter", func() {
+		When("the name of the EnvoyFilter doesn't start with 'shoot-'", func() {
+			It("issues no patch for the EnvoyFilter", func() {
 				df, dfJSON := getEnvoyFilterFromFile("non-shoot-envoyfilter")
 
 				ar := e.createAdmissionResponse(context.Background(), df, dfJSON)
 
 				Expect(ar.Allowed).To(BeTrue())
-				Expect(string(ar.Patch)).To(Equal(""))
+				Expect(ar.Result.Message).To(ContainSubstring("not an EnvoyFilter managed by this webhook"))
+				Expect(ar.Patch).To(BeEmpty())
+			})
+		})
+
+		When("the shoot uses the legacy technical ID format 'shoot-'", func() {
+			It("should not exit early and handle the EnvoyFilter", func() {
+				df, dfJSON := getEnvoyFilterFromFile("shoot-foo-bar")
+
+				ar := e.createAdmissionResponse(context.Background(), df, dfJSON)
+
+				Expect(ar.Allowed).To(BeTrue())
+				Expect(ar.Result.Message).To(ContainSubstring("not enabled for shoot"))
+				Expect(ar.Patch).To(BeEmpty())
 			})
 		})
 
 		When("there is no extension", func() {
-			It("issues no patch for the EnvoyyFilter", func() {
+			It("issues no patch for the EnvoyFilter", func() {
 				df, dfJSON := getEnvoyFilterFromFile(namespace)
 
 				ar := e.createAdmissionResponse(context.Background(), df, dfJSON)
 
 				Expect(ar.Allowed).To(BeTrue())
-				Expect(string(ar.Patch)).To(Equal(""))
+				Expect(ar.Result.Message).To(ContainSubstring("not enabled for shoot"))
+				Expect(ar.Patch).To(BeEmpty())
 			})
 		})
 


### PR DESCRIPTION
The extension's `EnvoyFilter` webhook incorrectly filters for the `shoot--` prefix.
However, very old shoots use the `shoot-` prefix (note: one dash less).

This PR ensures the webhook correctly works for shoots with a technical ID using the legacy format.