### PR TITLE
Make ACL for shoot ingresses optional

### DIFF
--- a/pkg/controller/suite_test.go
+++ b/pkg/controller/suite_test.go
@@ -72,11 +72,6 @@ var _ = BeforeSuite(func() {
 	Expect(err).ToNot(HaveOccurred())
 	Expect(k8sClient).NotTo(BeNil())
 	createGardenNamespace()
-	istioNamespaceSelector := map[string]string{
-		"app":   "istio-ingressgateway",
-		"istio": "ingressgateway",
-	}
-	createNewGateway("nginx-ingress-controller", "garden", istioNamespaceSelector)
 })
 
 var _ = AfterSuite(func() {
@@ -150,7 +145,7 @@ func createNewIstioDeployment(namespace string, labels map[string]string) {
 	Expect(k8sClient.Create(ctx, deployment)).ShouldNot(HaveOccurred())
 }
 
-func createNewGateway(name, shootNamespace string, labels map[string]string) {
+func createNewGateway(name, shootNamespace string, labels map[string]string) *istionetworkingv1beta1.Gateway {
 	gw := &istionetworkingv1beta1.Gateway{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
@@ -161,6 +156,7 @@ func createNewGateway(name, shootNamespace string, labels map[string]string) {
 		},
 	}
 	Expect(k8sClient.Create(ctx, gw)).ShouldNot(HaveOccurred())
+	return gw
 }
 
 func createNewExtension(shootNamespace string, providerConfig []byte) *extensionsv1alpha1.Extension {
@@ -235,7 +231,9 @@ func createNewCluster(shootNamespace string) {
 							Pods:  nil,
 						},
 					},
-					Status: gardencorev1beta1.ShootStatus{ // needed to wait until k8s server is up and running
+					Status: gardencorev1beta1.ShootStatus{
+						TechnicalID: shootNamespace,
+						// needed to wait until k8s server is up and running
 						AdvertisedAddresses: []gardencorev1beta1.ShootAdvertisedAddress{{
 							Name: "test",
 							URL:  "https://test",


### PR DESCRIPTION
This PR is a follow-up to https://github.com/stackitcloud/gardener-extension-acl/pull/42.
It ensures, that the extension continues to work on gardener versions < v1.89, which don't have https://github.com/gardener/gardener/pull/9038.

Without this PR, extension reconciliations will fail with:
```
Error reconciling Extension: Gateway.networking.istio.io "nginx-ingress-controller" not found
```