### PR TITLE
Make VPN ACL filter more precise

### DIFF
--- a/docs/adr/02_envoyfilter_patching.md
+++ b/docs/adr/02_envoyfilter_patching.md
@@ -136,12 +136,12 @@ configPatches:
                               header:
                                 name: reversed-vpn
                                 string_match:
-                                  contains: shoot--projectname--shootname1
+                                  contains: .shoot--projectname--shootname1.
                           - not_id:
                               header:
                                 name: reversed-vpn
                                 string_match:
-                                  contains: shoot--projectname--shootname2
+                                  contains: .shoot--projectname--shootname2.
               # this is the shoot-specific policy, matching on both the header
               # AND the provided list of allowed IP ranges
               shoot--projectname--shootname1:
@@ -164,7 +164,7 @@ configPatches:
                     - header:
                         name: reversed-vpn
                         string_match:
-                          contains: shoot--projectname--shootname
+                          contains: .shoot--projectname--shootname.
               # one more policy for each shoot that has the extension enabled
               shoot-projectname-shootname2:
                 ...

--- a/docs/adr/02_envoyfilter_patching.md
+++ b/docs/adr/02_envoyfilter_patching.md
@@ -130,7 +130,7 @@ configPatches:
                   permissions:
                   - any: true
                   principals:
-                    - or_ids:
+                    - and_ids:
                         ids:
                           - not_id:
                               header:

--- a/pkg/envoyfilters/envoyfilters.go
+++ b/pkg/envoyfilters/envoyfilters.go
@@ -201,7 +201,7 @@ func CreateVPNConfigPatchFromRule(
 
 	policies := map[string]interface{}{}
 
-	policies[rbacName+"-inverse"] = createInversedVPNPolicy(mappings)
+	policies[rbacName+"-inverse"] = createInverseVPNPolicy(mappings)
 
 	for i := range mappings {
 		mapping := &mappings[i]
@@ -372,7 +372,7 @@ func createVPNPolicyForShoot(rule *ACLRule, alwaysAllowedCIDRs []string, technic
 	}
 }
 
-func createInversedVPNPolicy(mappings []ACLMapping) map[string]interface{} {
+func createInverseVPNPolicy(mappings []ACLMapping) map[string]interface{} {
 	notHeaderPrincipals := []map[string]interface{}{}
 
 	for i := range mappings {
@@ -394,7 +394,7 @@ func createInversedVPNPolicy(mappings []ACLMapping) map[string]interface{} {
 		},
 		"principals": []map[string]interface{}{
 			{
-				"or_ids": map[string]interface{}{
+				"and_ids": map[string]interface{}{
 					"ids": notHeaderPrincipals,
 				},
 			},

--- a/pkg/envoyfilters/envoyfilters.go
+++ b/pkg/envoyfilters/envoyfilters.go
@@ -361,7 +361,12 @@ func createVPNPolicyForShoot(rule *ACLRule, alwaysAllowedCIDRs []string, technic
 							"header": map[string]interface{}{
 								"name": "reversed-vpn",
 								"string_match": map[string]interface{}{
-									"contains": technicalShootID,
+									// The actual header value will look something like
+									// `outbound|1194||vpn-seed-server.<technical-ID>.svc.cluster.local`.
+									// Include dots in the contains matcher as anchors, to always match the entire technical shoot ID.
+									// Otherwise, if there was one cluster named `foo` and one named `foo-bar` (in the same project),
+									// `foo` would effectively inherit the ACL of `foo-bar`.
+									"contains": "." + technicalShootID + ".",
 								},
 							},
 						},
@@ -381,7 +386,12 @@ func createInverseVPNPolicy(mappings []ACLMapping) map[string]interface{} {
 				"header": map[string]interface{}{
 					"name": "reversed-vpn",
 					"string_match": map[string]interface{}{
-						"contains": mappings[i].ShootName,
+						// The actual header value will look something like
+						// `outbound|1194||vpn-seed-server.<technical-ID>.svc.cluster.local`.
+						// Include dots in the contains matcher as anchors, to always match the entire technical shoot ID.
+						// Otherwise, if there was one cluster named `foo` and one named `foo-bar` (in the same project),
+						// `foo` would effectively inherit the ACL of `foo-bar`.
+						"contains": "." + mappings[i].ShootName + ".",
 					},
 				},
 			},

--- a/pkg/envoyfilters/testdata/vpnEnvoyFilterSpecWithOneAllowRule.yaml
+++ b/pkg/envoyfilters/testdata/vpnEnvoyFilterSpecWithOneAllowRule.yaml
@@ -17,7 +17,7 @@ configPatches:
                   permissions:
                   - any: true
                   principals:
-                    - or_ids:
+                    - and_ids:
                         ids:
                           - not_id:
                               header:

--- a/pkg/envoyfilters/testdata/vpnEnvoyFilterSpecWithOneAllowRule.yaml
+++ b/pkg/envoyfilters/testdata/vpnEnvoyFilterSpecWithOneAllowRule.yaml
@@ -23,7 +23,7 @@ configPatches:
                               header:
                                 name: reversed-vpn
                                 string_match:
-                                  contains: shoot--projectname--shootname
+                                  contains: .shoot--projectname--shootname.
               shoot--projectname--shootname:
                 permissions:
                 - any: true
@@ -44,7 +44,7 @@ configPatches:
                     - header:
                         name: reversed-vpn
                         string_match:
-                          contains: shoot--projectname--shootname
+                          contains: .shoot--projectname--shootname.
           stat_prefix: envoyrbac
 workloadSelector:
   labels:


### PR DESCRIPTION
This PR makes the `contains` matcher in the VPN EnvoyFilter more precise.
The header value looks like `outbound|1194||vpn-seed-server.<technical-ID>.svc.cluster.local`.
We now include dots in the contains matcher as anchors, to always match the entire technical shoot ID.
Otherwise, if there is one cluster named `foo` and one named `foo-bar` (in the same project), `foo` would effectively inherit the ACL of `foo-bar`.

The PR also switches the inverse rule to `and_ids`. Using `or_ids` with a list of `not_id` makes the policy always allow traffic if multiple shoots use the ACL extension and run behind the same ingress gateway.

The more permanent solution to the problem is https://github.com/stackitcloud/gardener-extension-acl/pull/43.