### PR TITLE
Use relative path to tools and drop `make init`

### DIFF
--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -29,5 +29,4 @@ jobs:
     - uses: actions/setup-go@v4
       with:
         go-version-file: go.mod
-    - run: make init
     - run: make images PUSH=true

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -34,5 +34,4 @@ jobs:
       run: |
         git config --global user.email "ci@gardener.cloud"
         git config --global user.name "ci"
-    - run: make init
     - run: make verify-extended

--- a/Makefile
+++ b/Makefile
@@ -87,8 +87,6 @@ images: $(KO)
 tidy:
 	@GO111MODULE=on go mod tidy
 
-# run `make init` to perform an initial go mod cache sync which is required for other make targets
-init: tidy
 # needed so that check-generate.sh can call make revendor
 revendor: tidy
 

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ endif
 # Tools                                 #
 #########################################
 
-TOOLS_DIR := $(HACK_DIR)/tools
+TOOLS_DIR := hack/tools
 include $(GARDENER_HACK_DIR)/tools.mk
 include $(HACK_DIR)/tools.mk
 


### PR DESCRIPTION
Follow-up to #38. Instead of using an absolute path to the tools directory, we use a relative path again.
With this, previous CI configurations continue to work when executing things like
```
make hack/tools/bin/ko
```

Also we drop `make init` as the gardener module is automatically downloaded on a `make` invocation via the `ENSURE_GARDENER_MOD` var.