### PR TITLE
Don't match on full header values

### DIFF
--- a/docs/adr/06_seperate_vpn_filter.md
+++ b/docs/adr/06_seperate_vpn_filter.md
@@ -17,13 +17,13 @@ The resulting filter chain in envoy looks like this:
     "@type": "type.googleapis.com/envoy.extensions.filters.http.rbac.v3.RBAC",
     "rules": {
     "policies": {
-      "shoot-1": {
+      "shoot--1": {
       "permissions": [
         {
         "header": {
           "name": "reversed-vpn",
           "string_match": {
-          "exact": "outbound|1194||vpn-seed-server.shoot--shoot-1.svc.cluster.local"
+          "contains": ".shoot--shoot--1."
           }
         }
         }
@@ -38,14 +38,14 @@ The resulting filter chain in envoy looks like this:
 ...
       ]
       },
-      "shoot-1-inverse": {
+      "shoot--1-inverse": {
       "permissions": [
         {
         "not_rule": {
           "header": {
           "name": "reversed-vpn",
           "string_match": {
-            "exact": "outbound|1194||vpn-seed-server.shoot--shoot-1.svc.cluster.local"
+            "contains": ".shoot--shoot--1."
           }
           }
         }
@@ -70,13 +70,13 @@ The resulting filter chain in envoy looks like this:
     "@type": "type.googleapis.com/envoy.extensions.filters.http.rbac.v3.RBAC",
     "rules": {
     "policies": {
-      "shoot-2": {
+      "shoot--2": {
       "permissions": [
         {
         "header": {
           "name": "reversed-vpn",
           "string_match": {
-          "exact": "outbound|1194||vpn-seed-server.shoot--shoot-2.svc.cluster.local"
+          "contains": ".shoot--shoot--2."
           }
         }
         }
@@ -91,14 +91,14 @@ The resulting filter chain in envoy looks like this:
 ...
       ]
       },
-      "shoot-2-inverse": {
+      "shoot--2-inverse": {
       "permissions": [
         {
         "not_rule": {
           "header": {
           "name": "reversed-vpn",
           "string_match": {
-            "exact": "outbound|1194||vpn-seed-server.shoot--shoot-2.svc.cluster.local"
+            "contains": ".shoot--shoot--2."
           }
           }
         }

--- a/pkg/envoyfilters/testdata/vpnEnvoyFilterSpecWithOneAllowRule.yaml
+++ b/pkg/envoyfilters/testdata/vpnEnvoyFilterSpecWithOneAllowRule.yaml
@@ -19,7 +19,7 @@ configPatches:
                     header:
                       name: reversed-vpn
                       string_match:
-                        exact: outbound|1194||vpn-seed-server.shoot--bar--foo.svc.cluster.local
+                        contains: .shoot--bar--foo.
                 principals:
                 - remote_ip:
                     address_prefix: 0.0.0.0
@@ -29,7 +29,7 @@ configPatches:
                 - header:
                     name: reversed-vpn
                     string_match:
-                      exact: outbound|1194||vpn-seed-server.shoot--bar--foo.svc.cluster.local
+                      contains: .shoot--bar--foo.
                 principals:
                 - remote_ip:
                     address_prefix: 10.180.0.0


### PR DESCRIPTION
After https://github.com/stackitcloud/gardener-extension-acl/pull/43, this PR goes back to using `contains` for the `Reversed-VPN` header matcher similar to https://github.com/stackitcloud/gardener-extension-acl/pull/50.

We don't match with the full header value to allow service names and ports to change while still making sure we catch all traffic targeting this shoot.
ref https://github.com/stackitcloud/gardener/pull/69