### PR TITLE
Simplify shoot validator code

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,6 @@ require (
 	github.com/spf13/cobra v1.8.1
 	github.com/spf13/pflag v1.0.5
 	github.com/tidwall/gjson v1.17.1
-	go.uber.org/mock v0.4.0
 	golang.org/x/tools v0.22.0
 	gomodules.xyz/jsonpatch/v2 v2.4.0
 	gopkg.in/yaml.v3 v3.0.1
@@ -100,6 +99,7 @@ require (
 	github.com/spf13/afero v1.9.5 // indirect
 	github.com/tidwall/match v1.1.1 // indirect
 	github.com/tidwall/pretty v1.2.0 // indirect
+	go.uber.org/mock v0.4.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.26.0 // indirect
 	golang.org/x/crypto v0.24.0 // indirect

--- a/pkg/admission/validator/webhook.go
+++ b/pkg/admission/validator/webhook.go
@@ -23,7 +23,7 @@ func New(mgr manager.Manager) (*extensionswebhook.Webhook, error) {
 		Name:     Name,
 		Path:     "/webhooks/validate",
 		Validators: map[extensionswebhook.Validator][]extensionswebhook.Type{
-			NewShootValidator(mgr): {{Obj: &core.Shoot{}}},
+			NewShootValidator(): {{Obj: &core.Shoot{}}},
 		},
 		Target: extensionswebhook.TargetSeed,
 		ObjectSelector: &metav1.LabelSelector{


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR simplifies the shoot validator code. Mainly, it removes the need to pass a manager to the constructor, which was unused. 
This is done as a preparation for https://github.com/stackitcloud/gardener-extension-acl/pull/62, where linting fails exactly at this place for the unused manager.

Along the way, the field paths returned by the validator are corrected to point to the exact index in `spec.extensions`.
I.e., instead of returning `spec.extensions.providerConfig.*`, it now returns `spec.extensions[0].providerConfig.*`.

**Which issue(s) this PR fixes**:
n/a

**Special notes for your reviewer**:
