### PR TITLE
Use ServiceTrafficDistribution to make Services topology-aware when runtime Kubernetes >= 1.31

### DIFF
--- a/charts/gardener-extension-admission-acl/charts/runtime/templates/service.yaml
+++ b/charts/gardener-extension-admission-acl/charts/runtime/templates/service.yaml
@@ -5,8 +5,8 @@ metadata:
   namespace: {{ .Release.Namespace }}
   annotations:
     networking.resources.gardener.cloud/from-all-webhook-targets-allowed-ports: '[{"protocol":"TCP","port":{{ .Values.global.webhookConfig.serverPort }}}]'
-    {{- if .Values.global.service.topologyAwareRouting.enabled }}
-    {{- if semverCompare ">= 1.27-0" .Capabilities.KubeVersion.GitVersion }}
+    {{- if and .Values.global.service.topologyAwareRouting.enabled (semverCompare "< 1.31-0" .Capabilities.KubeVersion.Version) }}
+    {{- if semverCompare ">= 1.27-0" .Capabilities.KubeVersion.Version }}
     service.kubernetes.io/topology-mode: "auto"
     {{- else }}
     service.kubernetes.io/topology-aware-hints: "auto"
@@ -14,7 +14,7 @@ metadata:
     {{- end }}
   labels:
 {{ include "labels" . | indent 4 }}
-    {{- if .Values.global.service.topologyAwareRouting.enabled }}
+    {{- if and .Values.global.service.topologyAwareRouting.enabled (semverCompare "< 1.32-0" .Capabilities.KubeVersion.Version) }}
     endpoint-slice-hints.resources.gardener.cloud/consider: "true"
     {{- end }}
 spec:
@@ -25,3 +25,6 @@ spec:
   - port: 443
     protocol: TCP
     targetPort: {{ .Values.global.webhookConfig.serverPort }}
+  {{- if and .Values.global.service.topologyAwareRouting.enabled (semverCompare ">= 1.31-0" .Capabilities.KubeVersion.Version) }}
+  trafficDistribution: PreferClose
+  {{- end }}


### PR DESCRIPTION
**What this PR does / why we need it**:
See more details in https://github.com/gardener/gardener/issues/10421 and https://github.com/gardener/gardener/pull/11178.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/10421

**Special notes for your reviewer**:
N/A