### PR TITLE
Reconcile on infra change

### DIFF
--- a/cmd/gardener-extension-acl/app/app.go
+++ b/cmd/gardener-extension-acl/app/app.go
@@ -25,7 +25,7 @@ import (
 	istionetworkv1alpha3 "istio.io/client-go/pkg/apis/networking/v1alpha3"
 	istionetworkv1beta1 "istio.io/client-go/pkg/apis/networking/v1beta1"
 	corev1 "k8s.io/api/core/v1"
-	componentbaseconfig "k8s.io/component-base/config/v1alpha1"
+	componentbaseconfigv1alpha1 "k8s.io/component-base/config/v1alpha1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
@@ -59,7 +59,7 @@ func NewControllerManagerCommand(ctx context.Context) *cobra.Command {
 
 func (o *Options) run(ctx context.Context) error {
 	// TODO: Make these flags configurable via command line parameters or component config file.
-	util.ApplyClientConnectionConfigurationToRESTConfig(&componentbaseconfig.ClientConnectionConfiguration{
+	util.ApplyClientConnectionConfigurationToRESTConfig(&componentbaseconfigv1alpha1.ClientConnectionConfiguration{
 		QPS:   100.0,
 		Burst: 130,
 	}, o.restOptions.Completed().Config)

--- a/cmd/gardener-extension-admission-acl/app/app.go
+++ b/cmd/gardener-extension-admission-acl/app/app.go
@@ -16,7 +16,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
-	componentbaseconfig "k8s.io/component-base/config/v1alpha1"
+	componentbaseconfigv1alpha1 "k8s.io/component-base/config/v1alpha1"
 	"k8s.io/component-base/version"
 	"k8s.io/component-base/version/verflag"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
@@ -89,7 +89,7 @@ func NewControllerManagerCommand(ctx context.Context) *cobra.Command {
 			}
 			validator.DefaultAddOptions.MaxAllowedCIDRs = admissionOptions.Completed().MaxAllowedCIDRs
 
-			util.ApplyClientConnectionConfigurationToRESTConfig(&componentbaseconfig.ClientConnectionConfiguration{
+			util.ApplyClientConnectionConfigurationToRESTConfig(&componentbaseconfigv1alpha1.ClientConnectionConfiguration{
 				QPS:   100.0,
 				Burst: 130,
 			}, restOpts.Completed().Config)

--- a/pkg/cmd/options.go
+++ b/pkg/cmd/options.go
@@ -18,7 +18,7 @@ package cmd
 import (
 	"time"
 
-	extensionsconfig "github.com/gardener/gardener/extensions/pkg/apis/config/v1alpha1"
+	extensionsconfigv1alpha1 "github.com/gardener/gardener/extensions/pkg/apis/config/v1alpha1"
 	extensionscmdcontroller "github.com/gardener/gardener/extensions/pkg/controller/cmd"
 	extensionshealthcheckcontroller "github.com/gardener/gardener/extensions/pkg/controller/healthcheck"
 	extensionscmdwebhook "github.com/gardener/gardener/extensions/pkg/webhook/cmd"
@@ -75,7 +75,7 @@ func (o *ExtensionOptions) Apply(config *controllerconfig.Config) {
 }
 
 // ApplyHealthCheckConfig applies the ExtensionOptions to the passed HealthCheckConfig.
-func (o *ExtensionOptions) ApplyHealthCheckConfig(config *extensionsconfig.HealthCheckConfig) {
+func (o *ExtensionOptions) ApplyHealthCheckConfig(config *extensionsconfigv1alpha1.HealthCheckConfig) {
 	config.SyncPeriod.Duration = o.HealthCheckSyncPeriod
 }
 

--- a/pkg/controller/add.go
+++ b/pkg/controller/add.go
@@ -17,20 +17,21 @@ package controller
 
 import (
 	"context"
-	"k8s.io/apimachinery/pkg/types"
-	"reflect"
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	extensionscontroller "github.com/gardener/gardener/extensions/pkg/controller"
 	"github.com/gardener/gardener/extensions/pkg/controller/extension"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
-	controllerconfig "github.com/stackitcloud/gardener-extension-acl/pkg/controller/config"
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
+
+	controllerconfig "github.com/stackitcloud/gardener-extension-acl/pkg/controller/config"
 )
 
 const (
@@ -81,7 +82,7 @@ func infrastructurePredicate() predicate.TypedFuncs[*extensionsv1alpha1.Infrastr
 	return predicate.TypedFuncs[*extensionsv1alpha1.Infrastructure]{
 		UpdateFunc: func(e event.TypedUpdateEvent[*extensionsv1alpha1.Infrastructure]) bool {
 			// We want to reconcile if the status of the Infrastructure changed
-			return !reflect.DeepEqual(e.ObjectOld.Status, e.ObjectNew.Status)
+			return !apiequality.Semantic.DeepEqual(e.ObjectOld.Status, e.ObjectNew.Status)
 		},
 		CreateFunc: func(_ event.TypedCreateEvent[*extensionsv1alpha1.Infrastructure]) bool {
 			return false
@@ -97,23 +98,19 @@ func infrastructurePredicate() predicate.TypedFuncs[*extensionsv1alpha1.Infrastr
 
 // watchInfrastructure watches for Infrastructure changes and triggers the Extension reconciliation.
 func watchInfrastructure(mgr manager.Manager) extensionscontroller.WatchBuilder {
-	infraStatusChangedPredicate := infrastructurePredicate()
-
 	// Map Infrastructure changes to the Extension
 	mapFunc := func(_ context.Context, infrastructure *extensionsv1alpha1.Infrastructure) []reconcile.Request {
-		return []reconcile.Request{
-			{NamespacedName: types.NamespacedName{
-				Name:      Type,
-				Namespace: infrastructure.Namespace,
-			}},
-		}
+		return []reconcile.Request{{NamespacedName: types.NamespacedName{
+			Name:      Type,
+			Namespace: infrastructure.Namespace,
+		}}}
 	}
 
 	// Watch for Infrastructure changes outside shoot reconciliation
-	watchBuilder := extensionscontroller.NewWatchBuilder(func(ctrl controller.Controller) error {
+	return extensionscontroller.NewWatchBuilder(func(ctrl controller.Controller) error {
 		return ctrl.Watch(source.Kind(mgr.GetCache(), &extensionsv1alpha1.Infrastructure{},
 			handler.TypedEnqueueRequestsFromMapFunc(mapFunc),
-			[]predicate.TypedPredicate[*extensionsv1alpha1.Infrastructure]{infraStatusChangedPredicate}...))
+			infrastructurePredicate(),
+		))
 	})
-	return watchBuilder
 }

--- a/pkg/controller/add_test.go
+++ b/pkg/controller/add_test.go
@@ -59,7 +59,6 @@ var _ = Describe("infrastructurePredicate", func() {
 
 	Describe("#Update", func() {
 		It("should return true if EgressCIDRs changed", func() {
-
 			newInfra := infra.DeepCopy()
 			newInfra.Status.EgressCIDRs = append(newInfra.Status.EgressCIDRs, "42.43.44.45/32")
 

--- a/pkg/controller/add_test.go
+++ b/pkg/controller/add_test.go
@@ -1,0 +1,82 @@
+// Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved.
+// This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package controller
+
+import (
+	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+)
+
+var _ = Describe("infrastructurePredicate", func() {
+	var (
+		p     predicate.TypedPredicate[*extensionsv1alpha1.Infrastructure]
+		infra *extensionsv1alpha1.Infrastructure
+	)
+
+	BeforeEach(func() {
+		p = infrastructurePredicate()
+
+		infra = &extensionsv1alpha1.Infrastructure{
+			Status: extensionsv1alpha1.InfrastructureStatus{
+				EgressCIDRs: []string{"52.53.54.55/32"},
+			},
+		}
+	})
+
+	Describe("#Create", func() {
+		It("should return false", func() {
+			Expect(p.Create(event.TypedCreateEvent[*extensionsv1alpha1.Infrastructure]{})).To(BeFalse())
+		})
+	})
+
+	Describe("#Delete", func() {
+		It("should return false", func() {
+			Expect(p.Delete(event.TypedDeleteEvent[*extensionsv1alpha1.Infrastructure]{})).To(BeFalse())
+		})
+	})
+
+	Describe("#Generic", func() {
+		It("should return false", func() {
+			Expect(p.Generic(event.TypedGenericEvent[*extensionsv1alpha1.Infrastructure]{})).To(BeFalse())
+		})
+	})
+
+	Describe("#Update", func() {
+		It("should return true if EgressCIDRs changed", func() {
+
+			newInfra := infra.DeepCopy()
+			newInfra.Status.EgressCIDRs = append(newInfra.Status.EgressCIDRs, "42.43.44.45/32")
+
+			Expect(p.Update(event.TypedUpdateEvent[*extensionsv1alpha1.Infrastructure]{ObjectNew: newInfra, ObjectOld: infra})).To(BeTrue())
+		})
+
+		It("should return false if EgressCIDRs have not changed", func() {
+			newInfra := infra.DeepCopy()
+
+			Expect(p.Update(event.TypedUpdateEvent[*extensionsv1alpha1.Infrastructure]{ObjectNew: newInfra, ObjectOld: infra})).To(BeFalse())
+		})
+
+		It("should return true if any other status field changed", func() {
+			newInfra := infra.DeepCopy()
+			newInfra.Status.NodesCIDR = ptr.To("100.212.123.18/27")
+
+			Expect(p.Update(event.TypedUpdateEvent[*extensionsv1alpha1.Infrastructure]{ObjectNew: newInfra, ObjectOld: infra})).To(BeTrue())
+		})
+	})
+})

--- a/pkg/controller/healthcheck/add.go
+++ b/pkg/controller/healthcheck/add.go
@@ -18,7 +18,7 @@ package healthcheck
 import (
 	"context"
 
-	extensionsconfig "github.com/gardener/gardener/extensions/pkg/apis/config/v1alpha1"
+	extensionsconfigv1alpha1 "github.com/gardener/gardener/extensions/pkg/apis/config/v1alpha1"
 	"github.com/gardener/gardener/extensions/pkg/controller/healthcheck"
 	"github.com/gardener/gardener/extensions/pkg/controller/healthcheck/general"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
@@ -34,7 +34,7 @@ import (
 var (
 	// DefaultAddOptions contains the default options for the healthchecks.
 	DefaultAddOptions = healthcheck.DefaultAddArgs{
-		HealthCheckConfig: extensionsconfig.HealthCheckConfig{SyncPeriod: metav1.Duration{}},
+		HealthCheckConfig: extensionsconfigv1alpha1.HealthCheckConfig{SyncPeriod: metav1.Duration{}},
 	}
 )
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Some infrastructures may provide dynamic updates of egress IPs. It may be due to dynamic NAT gateways scaling up if required or it might be some other means. An non-standard example is Azure, which allows load balancers to be used as NAT gateways. Therefore, if a new load balancer is created it may be used as egress IP. Hence, the allowlisting configuration needs to be adapted as soon as possible to prevent blocking valid traffic.

Otherwise the cluster may be partially unreachable until the ACL extension has been reconciled and allows traffic from the changed egress IPs.

**Special notes for your reviewer**:
- Depends on gardener v1.111 which was also bumped in this PR
- Reason for this was missing support for `WatchBuilder` in the extension API which I added in [this commit](https://github.com/gardener/gardener/commit/c97ea1f145964bc977bfe471f0de6ff96efb9442)