### PR TITLE
Drop support for Shoots with Kubernetes version <= 1.26

### DIFF
--- a/charts/gardener-extension-admission-acl/charts/runtime/templates/service.yaml
+++ b/charts/gardener-extension-admission-acl/charts/runtime/templates/service.yaml
@@ -6,11 +6,7 @@ metadata:
   annotations:
     networking.resources.gardener.cloud/from-all-webhook-targets-allowed-ports: '[{"protocol":"TCP","port":{{ .Values.global.webhookConfig.serverPort }}}]'
     {{- if and .Values.global.service.topologyAwareRouting.enabled (semverCompare "< 1.31-0" .Capabilities.KubeVersion.Version) }}
-    {{- if semverCompare ">= 1.27-0" .Capabilities.KubeVersion.Version }}
     service.kubernetes.io/topology-mode: "auto"
-    {{- else }}
-    service.kubernetes.io/topology-aware-hints: "auto"
-    {{- end }}
     {{- end }}
   labels:
 {{ include "labels" . | indent 4 }}

--- a/hack/prepare-envtest.sh
+++ b/hack/prepare-envtest.sh
@@ -4,7 +4,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-ENVTEST_K8S_VERSION=${ENVTEST_K8S_VERSION:-"1.26"}
+ENVTEST_K8S_VERSION=${ENVTEST_K8S_VERSION:-"1.30"}
 
 echo "> Installing envtest tools@${ENVTEST_K8S_VERSION} with setup-envtest if necessary"
 if ! command -v setup-envtest &> /dev/null ; then


### PR DESCRIPTION
**What this PR does / why we need it**:
- [x] Adapt service.kubernetes.io/topology-mode annotation

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/10339

**Special notes for your reviewer**:
N/A