### PR TITLE
Add controls for Pod Security Standards `restricted` policy

### DIFF
--- a/charts/gardener-extension-acl/templates/deployment.yaml
+++ b/charts/gardener-extension-acl/templates/deployment.yaml
@@ -61,8 +61,10 @@ spec:
           capabilities:
             drop: [ALL]
           runAsNonRoot: true
-          runAsUser: 1337
-          runAsGroup: 1337
+          runAsUser: 65532
+          runAsGroup: 65532
+          seccompProfile:
+            type: RuntimeDefault
         {{- if .Values.imageVectorOverwrite }}
         volumeMounts:
         - name: extension-imagevector-overwrite

--- a/charts/gardener-extension-acl/templates/deployment.yaml
+++ b/charts/gardener-extension-acl/templates/deployment.yaml
@@ -58,6 +58,11 @@ spec:
         {{- end }}
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop: [ALL]
+          runAsNonRoot: true
+          runAsUser: 1337
+          runAsGroup: 1337
         {{- if .Values.imageVectorOverwrite }}
         volumeMounts:
         - name: extension-imagevector-overwrite

--- a/charts/gardener-extension-admission-acl/charts/runtime/templates/deployment.yaml
+++ b/charts/gardener-extension-admission-acl/charts/runtime/templates/deployment.yaml
@@ -90,8 +90,10 @@ spec:
           capabilities:
             drop: [ALL]
           runAsNonRoot: true
-          runAsUser: 1337
-          runAsGroup: 1337
+          runAsUser: 65532
+          runAsGroup: 65532
+          seccompProfile:
+            type: RuntimeDefault
         volumeMounts:
         {{- if .Values.kubeconfig }}
         - name: gardener-extension-admission-acl-kubeconfig

--- a/charts/gardener-extension-admission-acl/charts/runtime/templates/deployment.yaml
+++ b/charts/gardener-extension-admission-acl/charts/runtime/templates/deployment.yaml
@@ -87,6 +87,11 @@ spec:
 {{- end }}
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop: [ALL]
+          runAsNonRoot: true
+          runAsUser: 1337
+          runAsGroup: 1337
         volumeMounts:
         {{- if .Values.kubeconfig }}
         - name: gardener-extension-admission-acl-kubeconfig


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds settings to the deployment templates to comply with the Pod Security Standards `restricted` policy controls: https://kubernetes.io/docs/concepts/security/pod-security-standards/#restricted

**Which issue(s) this PR fixes**:
-

**Special notes for your reviewer**:
-
