### PR TITLE
Drop support for K8s `<= 1.31`

### DIFF
--- a/charts/gardener-extension-admission-acl/charts/runtime/templates/service.yaml
+++ b/charts/gardener-extension-admission-acl/charts/runtime/templates/service.yaml
@@ -5,14 +5,8 @@ metadata:
   namespace: {{ .Release.Namespace }}
   annotations:
     networking.resources.gardener.cloud/from-all-webhook-targets-allowed-ports: '[{"protocol":"TCP","port":{{ .Values.webhookConfig.serverPort }}}]'
-    {{- if and .Values.service.topologyAwareRouting.enabled (semverCompare "< 1.31-0" .Capabilities.KubeVersion.Version) }}
-    service.kubernetes.io/topology-mode: "auto"
-    {{- end }}
   labels:
 {{ include "labels" . | indent 4 }}
-    {{- if and .Values.service.topologyAwareRouting.enabled (semverCompare "< 1.32-0" .Capabilities.KubeVersion.Version) }}
-    endpoint-slice-hints.resources.gardener.cloud/consider: "true"
-    {{- end }}
 spec:
   type: ClusterIP
   selector:
@@ -21,7 +15,7 @@ spec:
   - port: 443
     protocol: TCP
     targetPort: {{ .Values.webhookConfig.serverPort }}
-  {{- if and .Values.service.topologyAwareRouting.enabled (semverCompare ">= 1.31-0" .Capabilities.KubeVersion.Version) (semverCompare "< 1.34-0" .Capabilities.KubeVersion.Version) }}
+  {{- if and .Values.service.topologyAwareRouting.enabled (semverCompare "< 1.34-0" .Capabilities.KubeVersion.Version) }}
   trafficDistribution: PreferClose
   {{- end }}
   {{- if and .Values.service.topologyAwareRouting.enabled (semverCompare ">= 1.34-0" .Capabilities.KubeVersion.Version) }}


### PR DESCRIPTION
**What this PR does / why we need it**:
Cleans up the support for K8s `<= 1.31` (removed with Gardener [`v1.142`](https://github.com/gardener/gardener/releases/tag/untagged-5c2028c4cfb83502f8ff)).

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/13919

**Special notes for your reviewer**:
