### PR TITLE
assign ske-networking as code owners

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -14,6 +14,9 @@
   automergeStrategy: 'squash',
   // required for automerging patch updates
   separateMinorPatch: true,
+  reviewers: [
+    'team:ske-networking'
+  ],
   additionalReviewers: [
     'robinschneider',
     'timebertt',

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -14,12 +14,8 @@
   automergeStrategy: 'squash',
   // required for automerging patch updates
   separateMinorPatch: true,
-  reviewers: [
-    'team:ske-networking'
-  ],
   additionalReviewers: [
-    'robinschneider',
-    'timebertt',
+    'team:ske-networking'
   ],
   customManagers: [
     {

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @timebertt @robinschneider @maboehm @hown3d
+* @stackitcloud/ske-networking


### PR DESCRIPTION
**What this PR does / why we need it**:
This change adds the SKE networking crew as code owner and default reviewer for this project.

**Which issue(s) this PR fixes**:
Fixes STACKITSKE-7527

**Special notes for your reviewer**:
